### PR TITLE
Implement convention model builder support for NonNullable Reference …

### DIFF
--- a/src/Microsoft.OData.ModelBuilder/Conventions/Attributes/NullableAttributeEdmPropertyConvention.cs
+++ b/src/Microsoft.OData.ModelBuilder/Conventions/Attributes/NullableAttributeEdmPropertyConvention.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics.Contracts;
+using System.Linq;
+
+namespace Microsoft.OData.ModelBuilder.Conventions.Attributes
+{
+    /// <summary>
+    /// Configures properties that have the NullableAttribute.
+    /// </summary>
+    /// <remarks>This MUST come after RequiredAttribute</remarks>
+    internal class NullableAttributeEdmPropertyConvention : AttributeEdmPropertyConvention<PropertyConfiguration>
+    {
+        //
+        // For the interpretation of nullability metadata, see
+        // https://github.com/dotnet/roslyn/blob/master/docs/features/nullable-metadata.md
+        //
+
+        private const string NullableAttributeFullName = "System.Runtime.CompilerServices.NullableAttribute";
+
+        internal static readonly Func<Attribute, bool> NullableAttributeFilter = attribute => attribute.GetType().FullName == NullableAttributeFullName;
+
+        public NullableAttributeEdmPropertyConvention()
+            : base(NullableAttributeFilter, allowMultiple: false)
+        {
+        }
+
+        /// <summary>
+        /// Configures property's NonNullablity.
+        /// </summary>
+        /// <param name="edmProperty">The key property.</param>
+        /// <param name="structuralTypeConfiguration">The edm type being configured.</param>
+        /// <param name="attribute">The <see cref="Attribute"/> found on the property.</param>
+        /// <param name="model">The ODataConventionModelBuilder used to build the model.</param>
+        public override void Apply(PropertyConfiguration edmProperty,
+            StructuralTypeConfiguration structuralTypeConfiguration,
+            Attribute attribute,
+            ODataConventionModelBuilder model)
+        {
+            Contract.Assert(edmProperty != null);
+
+            //
+            // Check if already NonNullable
+            //
+            if (edmProperty.NonNullable())
+            {
+                return;
+            }
+
+            var nullableFlagsFieldInfo = attribute.GetType().GetField("NullableFlags");
+            if (nullableFlagsFieldInfo?.GetValue(attribute) is byte[] flags)
+            {
+                //
+                // flags:
+                // 0 oblivious
+                // 1 not annotated
+                // 2 annotated
+                //
+                if (flags.FirstOrDefault() == 1 && !edmProperty.ReturnMaybeNull())
+                {
+                    edmProperty.SetNonNullable();
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.OData.ModelBuilder/Conventions/Attributes/NullableContextAttributeEdmTypeConvention.cs
+++ b/src/Microsoft.OData.ModelBuilder/Conventions/Attributes/NullableContextAttributeEdmTypeConvention.cs
@@ -1,0 +1,99 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using System.Linq;
+using System.Reflection;
+
+namespace Microsoft.OData.ModelBuilder.Conventions.Attributes
+{
+    /// <summary>
+    /// Configures properties of a Type that has the NullableContextAttribute.
+    /// </summary>
+    /// <remarks>This MUST come after NullableAttribute</remarks>
+    internal class NullableContextAttributeEdmTypeConvention : AttributeEdmTypeConvention<StructuralTypeConfiguration>
+    {
+        //
+        // For the interpretation of nullability metadata, see
+        // https://github.com/dotnet/roslyn/blob/master/docs/features/nullable-metadata.md
+        //
+
+        private const string NullableContextAttributeFullName = "System.Runtime.CompilerServices.NullableContextAttribute";
+
+        public NullableContextAttributeEdmTypeConvention()
+            : base(attribute => attribute.GetType().FullName == NullableContextAttributeFullName, allowMultiple: false)
+        {
+        }
+
+        /// <summary>
+        /// Configures the NonNullablity of a type's properties based on the NullableContext.
+        /// </summary>
+        /// <param name="edmTypeConfiguration">The edm type being configured.</param>
+        /// <param name="attribute">The <see cref="Attribute"/> found on the property.</param>
+        /// <param name="model">The ODataConventionModelBuilder used to build the model.</param>
+        public override void Apply(StructuralTypeConfiguration edmTypeConfiguration,
+                                   ODataConventionModelBuilder model,
+                                   Attribute attribute)
+        {
+            Contract.Assert(edmTypeConfiguration != null);
+
+            //
+            // Only propagate Nullability if flag == 1 (not annotated)
+            //
+            if (attribute.GetType().GetField("Flag")?.GetValue(attribute) is byte flag && flag != 1)
+            {
+                return;
+            }
+
+            var declaredOnlyProperties = edmTypeConfiguration.ClrType.GetProperties(BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Public);
+            var declaredOnlyPropertyNames = new HashSet<string>(declaredOnlyProperties.Select(p => p.Name));
+
+            foreach (var edmProperty in edmTypeConfiguration.Properties.ToArray())
+            {
+                //
+                // The NullableContextAttribute is not inherited so only apply to declared properties
+                //
+                if (!declaredOnlyPropertyNames.Contains(edmProperty.Name))
+                {
+                    continue;
+                }
+
+                //
+                // Do not propagate if it is a value type
+                //
+                if (TypeHelper.IsValueType(edmProperty.PropertyInfo.PropertyType))
+                {
+                    continue;
+                }
+
+                //
+                // Only propagate the NullableContext to properties without a Nullable attribute
+                //      
+                if (GetNullableAttribute(edmProperty.PropertyInfo) != null)
+                {
+                    continue;
+                }
+
+                if (!edmProperty.ReturnMaybeNull())
+                {
+                    edmProperty.SetNonNullable();
+                }
+
+                //
+                // Similar to EF Core, do not try to propagate nullability for generic properties, since calculating
+                // that is complex (depends on the nullability of generic type argument).
+                // Unlike EF Core, do not special case Dictionary as OData uses that exclusively for open types
+                // where NonNullability is not a factor.
+                //
+            }
+        }
+
+        private Attribute GetNullableAttribute(MemberInfo member)
+            => member?.GetCustomAttributes(inherit: true)
+                      .OfType<Attribute>()
+                      .Where(NullableAttributeEdmPropertyConvention.NullableAttributeFilter)
+                      .FirstOrDefault();
+    }
+}

--- a/src/Microsoft.OData.ModelBuilder/Microsoft.OData.ModelBuilder.xml
+++ b/src/Microsoft.OData.ModelBuilder/Microsoft.OData.ModelBuilder.xml
@@ -1976,6 +1976,35 @@
             Ignores properties with the NotMappedAttribute from <see cref="T:Microsoft.OData.Edm.IEdmStructuredType"/>.
             </summary>
         </member>
+        <member name="T:Microsoft.OData.ModelBuilder.Conventions.Attributes.NullableAttributeEdmPropertyConvention">
+            <summary>
+            Configures properties that have the NullableAttribute.
+            </summary>
+            <remarks>This MUST come after RequiredAttribute</remarks>
+        </member>
+        <member name="M:Microsoft.OData.ModelBuilder.Conventions.Attributes.NullableAttributeEdmPropertyConvention.Apply(Microsoft.OData.ModelBuilder.PropertyConfiguration,Microsoft.OData.ModelBuilder.StructuralTypeConfiguration,System.Attribute,Microsoft.OData.ModelBuilder.ODataConventionModelBuilder)">
+            <summary>
+            Configures property's NonNullablity.
+            </summary>
+            <param name="edmProperty">The key property.</param>
+            <param name="structuralTypeConfiguration">The edm type being configured.</param>
+            <param name="attribute">The <see cref="T:System.Attribute"/> found on the property.</param>
+            <param name="model">The ODataConventionModelBuilder used to build the model.</param>
+        </member>
+        <member name="T:Microsoft.OData.ModelBuilder.Conventions.Attributes.NullableContextAttributeEdmTypeConvention">
+            <summary>
+            Configures properties of a Type that has the NullableContextAttribute.
+            </summary>
+            <remarks>This MUST come after NullableAttribute</remarks>
+        </member>
+        <member name="M:Microsoft.OData.ModelBuilder.Conventions.Attributes.NullableContextAttributeEdmTypeConvention.Apply(Microsoft.OData.ModelBuilder.StructuralTypeConfiguration,Microsoft.OData.ModelBuilder.ODataConventionModelBuilder,System.Attribute)">
+            <summary>
+            Configures the NonNullablity of a type's properties based on the NullableContext.
+            </summary>
+            <param name="edmTypeConfiguration">The edm type being configured.</param>
+            <param name="attribute">The <see cref="T:System.Attribute"/> found on the property.</param>
+            <param name="model">The ODataConventionModelBuilder used to build the model.</param>
+        </member>
         <member name="M:Microsoft.OData.ModelBuilder.Conventions.Attributes.OrderByAttributeEdmTypeConvention.Apply(Microsoft.OData.ModelBuilder.StructuralTypeConfiguration,Microsoft.OData.ModelBuilder.ODataConventionModelBuilder,System.Attribute)">
             <summary>
             Set whether the $orderby can be applied on those properties of this structural type.
@@ -3618,6 +3647,31 @@
             <summary>
             Sets the property as countable.
             </summary>
+        </member>
+        <member name="T:Microsoft.OData.ModelBuilder.PropertyConfigurationExtensions">
+            <summary>
+            Extensions method for <see cref="T:Microsoft.OData.ModelBuilder.PropertyConfiguration"/>.
+            </summary>
+        </member>
+        <member name="M:Microsoft.OData.ModelBuilder.PropertyConfigurationExtensions.NonNullable(Microsoft.OData.ModelBuilder.PropertyConfiguration)">
+            <summary>
+            Determine if the EDM PropertyConfiguration is already set to be NonNullable
+            </summary>
+            <param name="edmProperty">The <see cref="T:Microsoft.OData.ModelBuilder.PropertyConfiguration"/> being extended.</param>
+            <returns><c>true</c> if NonNullable</returns>
+        </member>
+        <member name="M:Microsoft.OData.ModelBuilder.PropertyConfigurationExtensions.ReturnMaybeNull(Microsoft.OData.ModelBuilder.PropertyConfiguration)">
+            <summary>
+            Determine if the EDM PropertyConfiguration has [MaybeNull] on return value
+            </summary>
+            <param name="edmProperty">The <see cref="T:Microsoft.OData.ModelBuilder.PropertyConfiguration"/> being extended.</param>
+            <returns><c>true</c> if MaybeNull set</returns>
+        </member>
+        <member name="M:Microsoft.OData.ModelBuilder.PropertyConfigurationExtensions.SetNonNullable(Microsoft.OData.ModelBuilder.PropertyConfiguration)">
+            <summary>
+            Set the EDM PropertyConfiguration to be NonNullable
+            </summary>
+            <param name="edmProperty">The <see cref="T:Microsoft.OData.ModelBuilder.PropertyConfiguration"/> being extended.</param>
         </member>
         <member name="T:Microsoft.OData.ModelBuilder.PropertyKind">
             <summary>

--- a/src/Microsoft.OData.ModelBuilder/Property/PropertyConfigurationExtensions.cs
+++ b/src/Microsoft.OData.ModelBuilder/Property/PropertyConfigurationExtensions.cs
@@ -1,0 +1,106 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System.Diagnostics.Contracts;
+using System.Linq;
+
+namespace Microsoft.OData.ModelBuilder
+{
+    /// <summary>
+    /// Extensions method for <see cref="PropertyConfiguration"/>.
+    /// </summary>
+    internal static class PropertyConfigurationExtensions
+    {
+        /// <summary>
+        /// Determine if the EDM PropertyConfiguration is already set to be NonNullable
+        /// </summary>
+        /// <param name="edmProperty">The <see cref="PropertyConfiguration"/> being extended.</param>
+        /// <returns><c>true</c> if NonNullable</returns>
+        internal static bool NonNullable(this PropertyConfiguration edmProperty)
+        {
+            Contract.Assert(edmProperty != null);
+
+            //
+            // Check if already NonNullable
+            //
+            if (edmProperty is StructuralPropertyConfiguration structuralProperty && structuralProperty.NullableProperty == false)
+            {
+                return true;
+            }
+
+            if (edmProperty is NavigationPropertyConfiguration navigationProperty)
+            {
+                switch (navigationProperty.Multiplicity)
+                {
+                    case Edm.EdmMultiplicity.Many:      // Can't change Many
+                    case Edm.EdmMultiplicity.One:       // Already NonNullable
+                        return true;
+                    case Edm.EdmMultiplicity.Unknown:
+                    case Edm.EdmMultiplicity.ZeroOrOne:
+                    default:
+                        break;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Determine if the EDM PropertyConfiguration has [MaybeNull] on return value
+        /// </summary>
+        /// <param name="edmProperty">The <see cref="PropertyConfiguration"/> being extended.</param>
+        /// <returns><c>true</c> if MaybeNull set</returns>
+        internal static bool ReturnMaybeNull(this PropertyConfiguration edmProperty)
+        {
+            Contract.Assert(edmProperty != null);
+
+            const string MaybeNullAttributeFullName = "System.Diagnostics.CodeAnalysis.MaybeNullAttribute";
+
+            //
+            // Check for [MaybeNull] on the return value. If it exists, the member is nullable.
+            // Note: avoid using GetCustomAttribute<> below because of https://github.com/mono/mono/issues/17477
+            //
+            return ((edmProperty.PropertyInfo
+                                .GetMethod?
+                                .ReturnParameter)?
+                                .CustomAttributes)
+                                .Any(a => a.AttributeType.FullName == MaybeNullAttributeFullName);
+        }
+
+        /// <summary>
+        /// Set the EDM PropertyConfiguration to be NonNullable
+        /// </summary>
+        /// <param name="edmProperty">The <see cref="PropertyConfiguration"/> being extended.</param>
+        internal static void SetNonNullable(this PropertyConfiguration edmProperty)
+        {
+            Contract.Assert(edmProperty != null);
+
+            //
+            // Only make NonNullable if not already set
+            //
+            if (edmProperty is StructuralPropertyConfiguration structuralProperty)
+            {
+                if (structuralProperty.NullableProperty == false)
+                {
+                    return;
+                }
+
+                structuralProperty.NullableProperty = false;
+            }
+
+            if (edmProperty is NavigationPropertyConfiguration navigationProperty)
+            {
+                switch (navigationProperty.Multiplicity)
+                {
+                    case Edm.EdmMultiplicity.Many:      // Can't change Many
+                    case Edm.EdmMultiplicity.One:       // Already NonNullable
+                        return;
+                    default:
+                        break;
+                }
+
+                navigationProperty.Required();
+            }
+        }
+    }
+}

--- a/test/Microsoft.OData.ModelBuilder.Tests/Containers/EntitySetConfigurationTest.cs
+++ b/test/Microsoft.OData.ModelBuilder.Tests/Containers/EntitySetConfigurationTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.  See License.txt in the project root for license information.
 
 using System;
-using Microsoft.OData.Edm;
 using Microsoft.OData.ModelBuilder.Tests.Commons;
 using Xunit;
 
@@ -38,7 +37,7 @@ namespace Microsoft.OData.ModelBuilder.Tests.Containers
         [Fact]
         public void CtorThatTakesClrType_Throws_ArgumentNull_For_Name()
         {
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1 || NET5_0
             ExceptionAssert.Throws<ArgumentException>(
                 () => new EntitySetConfiguration(modelBuilder: new ODataModelBuilder(), entityClrType: typeof(EntitySetConfigurationTest), name: null),
                 "The argument 'name' is null or empty. (Parameter 'name')");
@@ -74,7 +73,7 @@ namespace Microsoft.OData.ModelBuilder.Tests.Containers
         [Fact]
         public void CtorThatTakesEntityTypeConfiguration_Throws_ArgumentNull_For_Name()
         {
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1 || NET5_0
             ExceptionAssert.Throws<ArgumentException>(
                 () => new EntitySetConfiguration(
                     modelBuilder: new ODataModelBuilder(),

--- a/test/Microsoft.OData.ModelBuilder.Tests/Conventions/Attributes/NullableAttributeEdmPropertyConventionTests.cs
+++ b/test/Microsoft.OData.ModelBuilder.Tests/Conventions/Attributes/NullableAttributeEdmPropertyConventionTests.cs
@@ -1,0 +1,422 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.OData.Edm;
+using Microsoft.OData.ModelBuilder.Conventions.Attributes;
+using Microsoft.OData.ModelBuilder.Tests.Commons;
+using Microsoft.OData.ModelBuilder.Tests.TestModels;
+using Xunit;
+
+namespace Microsoft.OData.ModelBuilder.Tests.Conventions.Attributes
+{
+    public class NullableAttributeEdmPropertyConventionTests
+    {
+        //
+        // The NullableAttribute is a compiler generated attribute that has no public specification
+        // and is injected into code. Additionally the compiler may optimize the NullableAttribute
+        // into a NullableContextAttribute. Thus it would be extremely difficult to Mock the inputs.
+        //
+
+        [Fact]
+        public void Empty_Ctor_DoesnotThrow()
+            => ExceptionAssert.DoesNotThrow(() => new NullableAttributeEdmPropertyConvention());
+
+        [Fact]
+        public void NullableAttributeEdmPropertyConvention_ConfiguresSimpleTypeWithNullable()
+        {
+            // Arrange         
+            var builder = new ODataConventionModelBuilder();
+            builder.EntitySet<Employee>("Employees");
+
+            // Act
+            var model = builder.GetEdmModel();
+
+            // Assert
+            model.AssertHasEntitySet("Employees", typeof(Employee));
+
+            var employeeEntity = model.AssertHasEntityType(typeof(Employee));
+            employeeEntity.AssertHasPrimitiveProperty(model, "EmployeeName", EdmPrimitiveTypeKind.String, isNullable: true);
+            employeeEntity.AssertHasNavigationProperty(model, "IsCeoOf", typeof(Company), isNullable: true, EdmMultiplicity.Many);
+            employeeEntity.AssertHasNavigationProperty(model, "WorkCompany", typeof(Company), isNullable: true, EdmMultiplicity.ZeroOrOne);
+            employeeEntity.AssertHasNavigationProperty(model, "Boss", typeof(Employee), isNullable: true, EdmMultiplicity.ZeroOrOne);
+            employeeEntity.AssertHasComplexProperty(model, "HomeAddress", typeof(Address), isNullable: true);
+            employeeEntity.AssertHasNavigationProperty(model, "DirectReports", typeof(Employee), isNullable: true, EdmMultiplicity.Many);
+
+            var addressEntity = model.AssertHasComplexType(typeof(Address));
+            addressEntity.AssertHasPrimitiveProperty(model, "Street", EdmPrimitiveTypeKind.String, isNullable: true);
+            addressEntity.AssertHasPrimitiveProperty(model, "City", EdmPrimitiveTypeKind.String, isNullable: true);
+            addressEntity.AssertHasPrimitiveProperty(model, "State", EdmPrimitiveTypeKind.String, isNullable: true);
+            addressEntity.AssertHasComplexProperty(model, "ZipCode", typeof(ZipCode), isNullable: true);
+            addressEntity.AssertHasPrimitiveProperty(model, "IgnoreThis", EdmPrimitiveTypeKind.String, isNullable: true);
+
+            var zipCodeEntity = model.AssertHasComplexType(typeof(ZipCode));
+            zipCodeEntity.AssertHasPrimitiveProperty(model, "Part1", EdmPrimitiveTypeKind.String, isNullable: true);
+            zipCodeEntity.AssertHasPrimitiveProperty(model, "Part1", EdmPrimitiveTypeKind.String, isNullable: true);
+        }
+
+        [Fact]
+        public void NullableAttributeEdmPropertyConvention_ConfiguresSimpleTypeWithNonNullable()
+        {
+            // Arrange         
+            var builder = new ODataConventionModelBuilder();
+            builder.EntitySet<TestModels.NonNullable.Employee>("Employees");
+
+            // Act
+            var model = builder.GetEdmModel();
+
+            // Assert
+            model.AssertHasEntitySet("Employees", typeof(TestModels.NonNullable.Employee));
+
+            var employeeEntity = model.AssertHasEntityType(typeof(TestModels.NonNullable.Employee));
+            employeeEntity.AssertHasPrimitiveProperty(model, "EmployeeName", EdmPrimitiveTypeKind.String, isNullable: false);
+            employeeEntity.AssertHasNavigationProperty(model, "IsCeoOf", typeof(TestModels.NonNullable.Company), isNullable: true, EdmMultiplicity.Many);
+            employeeEntity.AssertHasNavigationProperty(model, "WorkCompany", typeof(TestModels.NonNullable.Company), isNullable: false, EdmMultiplicity.One);
+            employeeEntity.AssertHasNavigationProperty(model, "Boss", typeof(TestModels.NonNullable.Employee), isNullable: false, EdmMultiplicity.One);
+            employeeEntity.AssertHasComplexProperty(model, "HomeAddress", typeof(TestModels.NonNullable.Address), isNullable: false);
+            employeeEntity.AssertHasComplexProperty(model, "VacationAddress", typeof(TestModels.NonNullable.Address), isNullable: false);
+            employeeEntity.AssertHasNavigationProperty(model, "DirectReports", typeof(TestModels.NonNullable.Employee), isNullable: true, EdmMultiplicity.Many);
+
+            var addressEntity = model.AssertHasComplexType(typeof(TestModels.NonNullable.Address));
+            addressEntity.AssertHasPrimitiveProperty(model, "Street", EdmPrimitiveTypeKind.String, isNullable: false);
+            addressEntity.AssertHasPrimitiveProperty(model, "City", EdmPrimitiveTypeKind.String, isNullable: false);
+            addressEntity.AssertHasPrimitiveProperty(model, "State", EdmPrimitiveTypeKind.String, isNullable: false);
+            addressEntity.AssertHasComplexProperty(model, "ZipCode", typeof(TestModels.NonNullable.ZipCode), isNullable: false);
+            addressEntity.AssertHasPrimitiveProperty(model, "IgnoreThis", EdmPrimitiveTypeKind.String, isNullable: false);
+
+            var zipCodeEntity = model.AssertHasComplexType(typeof(TestModels.NonNullable.ZipCode));
+            zipCodeEntity.AssertHasPrimitiveProperty(model, "Part1", EdmPrimitiveTypeKind.String, isNullable: false);
+            zipCodeEntity.AssertHasPrimitiveProperty(model, "Part2", EdmPrimitiveTypeKind.String, isNullable: true);
+        }
+
+        [Fact]
+        public void NullableAttributeEdmPropertyConvention_ConfiguresInheritedTypeWithNullable()
+        {
+            // Arrange         
+            var builder = new ODataConventionModelBuilder();
+            builder.EntitySet<Manager>("Managers");
+
+            // Act
+            var model = builder.GetEdmModel();
+
+            // Assert
+            model.AssertHasEntitySet("Managers", typeof(Manager));
+
+            var managerEntity = model.AssertHasEntityType(typeof(Manager));
+            managerEntity.AssertHasComplexProperty(model, "ExtraOffice", typeof(Address), isNullable: true);
+            managerEntity.AssertHasPrimitiveProperty(model, "EmployeeName", EdmPrimitiveTypeKind.String, isNullable: true);
+            managerEntity.AssertHasNavigationProperty(model, "IsCeoOf", typeof(Company), isNullable: true, EdmMultiplicity.Many);
+            managerEntity.AssertHasNavigationProperty(model, "WorkCompany", typeof(Company), isNullable: true, EdmMultiplicity.ZeroOrOne);
+            managerEntity.AssertHasNavigationProperty(model, "Boss", typeof(Employee), isNullable: true, EdmMultiplicity.ZeroOrOne);
+            managerEntity.AssertHasComplexProperty(model, "HomeAddress", typeof(Address), isNullable: true);
+            managerEntity.AssertHasNavigationProperty(model, "DirectReports", typeof(Employee), isNullable: true, EdmMultiplicity.Many);
+
+            var addressEntity = model.AssertHasComplexType(typeof(Address));
+            addressEntity.AssertHasPrimitiveProperty(model, "Street", EdmPrimitiveTypeKind.String, isNullable: true);
+            addressEntity.AssertHasPrimitiveProperty(model, "City", EdmPrimitiveTypeKind.String, isNullable: true);
+            addressEntity.AssertHasPrimitiveProperty(model, "State", EdmPrimitiveTypeKind.String, isNullable: true);
+            addressEntity.AssertHasComplexProperty(model, "ZipCode", typeof(ZipCode), isNullable: true);
+            addressEntity.AssertHasPrimitiveProperty(model, "IgnoreThis", EdmPrimitiveTypeKind.String, isNullable: true);
+
+            var zipCodeEntity = model.AssertHasComplexType(typeof(ZipCode));
+            zipCodeEntity.AssertHasPrimitiveProperty(model, "Part1", EdmPrimitiveTypeKind.String, isNullable: true);
+            zipCodeEntity.AssertHasPrimitiveProperty(model, "Part1", EdmPrimitiveTypeKind.String, isNullable: true);
+        }
+
+        [Fact]
+        public void NullableAttributeEdmPropertyConvention_ConfiguresInheritedTypeWithNonNullable()
+        {
+            // Arrange         
+            var builder = new ODataConventionModelBuilder();
+            builder.EntitySet<TestModels.NonNullable.Manager>("Managers");
+
+            // Act
+            var model = builder.GetEdmModel();
+
+            // Assert
+            model.AssertHasEntitySet("Managers", typeof(TestModels.NonNullable.Manager));
+
+            var managerEntity = model.AssertHasEntityType(typeof(TestModels.NonNullable.Manager));
+            managerEntity.AssertHasComplexProperty(model, "ExtraOffice", typeof(TestModels.NonNullable.Address), isNullable: true);
+            managerEntity.AssertHasPrimitiveProperty(model, "EmployeeName", EdmPrimitiveTypeKind.String, isNullable: false);
+            managerEntity.AssertHasNavigationProperty(model, "IsCeoOf", typeof(TestModels.NonNullable.Company), isNullable: true, EdmMultiplicity.Many);
+            managerEntity.AssertHasNavigationProperty(model, "WorkCompany", typeof(TestModels.NonNullable.Company), isNullable: false, EdmMultiplicity.One);
+            managerEntity.AssertHasNavigationProperty(model, "Boss", typeof(TestModels.NonNullable.Employee), isNullable: false, EdmMultiplicity.One);
+            managerEntity.AssertHasComplexProperty(model, "HomeAddress", typeof(TestModels.NonNullable.Address), isNullable: false);
+            managerEntity.AssertHasComplexProperty(model, "VacationAddress", typeof(TestModels.NonNullable.Address), isNullable: false);
+            managerEntity.AssertHasNavigationProperty(model, "DirectReports", typeof(TestModels.NonNullable.Employee), isNullable: true, EdmMultiplicity.Many);
+
+            var addressEntity = model.AssertHasComplexType(typeof(TestModels.NonNullable.Address));
+            addressEntity.AssertHasPrimitiveProperty(model, "Street", EdmPrimitiveTypeKind.String, isNullable: false);
+            addressEntity.AssertHasPrimitiveProperty(model, "City", EdmPrimitiveTypeKind.String, isNullable: false);
+            addressEntity.AssertHasPrimitiveProperty(model, "State", EdmPrimitiveTypeKind.String, isNullable: false);
+            addressEntity.AssertHasComplexProperty(model, "ZipCode", typeof(TestModels.NonNullable.ZipCode), isNullable: false);
+            addressEntity.AssertHasPrimitiveProperty(model, "IgnoreThis", EdmPrimitiveTypeKind.String, isNullable: false);
+
+            var zipCodeEntity = model.AssertHasComplexType(typeof(TestModels.NonNullable.ZipCode));
+            zipCodeEntity.AssertHasPrimitiveProperty(model, "Part1", EdmPrimitiveTypeKind.String, isNullable: false);
+            zipCodeEntity.AssertHasPrimitiveProperty(model, "Part2", EdmPrimitiveTypeKind.String, isNullable: true);
+        }
+
+        [Fact]
+        public void NullableAttributeEdmPropertyConvention_ConfiguresValueTypeWithNullable()
+        {
+            // Arrange         
+            var builder = new ODataConventionModelBuilder();
+            builder.EntitySet<Customer>("Customers");
+
+            // Act
+            var model = builder.GetEdmModel();
+
+            // Assert
+            model.AssertHasEntitySet("Customers", typeof(Customer));
+
+            var customerEntity = model.AssertHasEntityType(typeof(Customer));
+            customerEntity.AssertHasPrimitiveProperty(model, "Name", EdmPrimitiveTypeKind.String, isNullable: true);
+            customerEntity.AssertHasPrimitiveProperty(model, "SharePrice", EdmPrimitiveTypeKind.Decimal, isNullable: true);
+        }
+
+        [Fact]
+        public void NullableAttributeEdmPropertyConvention_ConfiguresValueTypeWithNonNullable()
+        {
+            // Arrange         
+            var builder = new ODataConventionModelBuilder();
+            builder.EntitySet<TestModels.NonNullable.Customer>("Customers");
+
+            // Act
+            var model = builder.GetEdmModel();
+
+            // Assert
+            model.AssertHasEntitySet("Customers", typeof(TestModels.NonNullable.Customer));
+
+            var customerEntity = model.AssertHasEntityType(typeof(TestModels.NonNullable.Customer));
+            customerEntity.AssertHasPrimitiveProperty(model, "Name", EdmPrimitiveTypeKind.String, isNullable: false);
+            customerEntity.AssertHasPrimitiveProperty(model, "SharePrice", EdmPrimitiveTypeKind.Decimal, isNullable: true);
+        }
+
+        [Fact]
+        public void NullableAttributeEdmPropertyConvention_ConfiguresDictionaryTypeWithNonNullable()
+        {
+            // Arrange         
+            var builder = new ODataConventionModelBuilder();
+            builder.EntitySet<TestModels.NonNullable.Customer>("Customers");
+
+            // Act
+            var model = builder.GetEdmModel();
+
+            // Assert
+            model.AssertHasEntitySet("Customers", typeof(TestModels.NonNullable.Customer));
+
+            var customerEntity = model.AssertHasEntityType(typeof(TestModels.NonNullable.Customer));
+            customerEntity.AssertHasPrimitiveProperty(model, "Name", EdmPrimitiveTypeKind.String, isNullable: false);
+            customerEntity.AssertHasPrimitiveProperty(model, "SharePrice", EdmPrimitiveTypeKind.Decimal, isNullable: true);
+        }
+
+        [Theory]
+        [InlineData(nameof(TestClassNullable.NonNullable), EdmPrimitiveTypeKind.String, false)]
+        [InlineData(nameof(TestClassNullable.Nullable), EdmPrimitiveTypeKind.String, true)]
+        [InlineData(nameof(TestClassNullable.NonNullablePropertyMaybeNull), EdmPrimitiveTypeKind.String, true)]
+        [InlineData(nameof(TestClassNullable.NonNullablePropertyAllowNull), EdmPrimitiveTypeKind.String, false)]
+        [InlineData(nameof(TestClassNullable.NullablePropertyNotNull), EdmPrimitiveTypeKind.String, true)]
+        [InlineData(nameof(TestClassNullable.NullablePropertyDisallowNull), EdmPrimitiveTypeKind.String, true)]
+        [InlineData(nameof(TestClassNullable.RequiredAndNullable), EdmPrimitiveTypeKind.String, false)]
+        [InlineData(nameof(TestClassNullable.NullObliviousNonNullable), EdmPrimitiveTypeKind.String, true)]
+        [InlineData(nameof(TestClassNullable.NullObliviousNullable), EdmPrimitiveTypeKind.String, true)]
+        public void Reference_nullability_sets_is_nullable_correctly(string propertyName, EdmPrimitiveTypeKind edmType, bool expectedNullable)
+        {
+            // Arrange         
+            var builder = new ODataConventionModelBuilder();
+            var entitySetName = nameof(TestClassNullable) + "s";
+            var type = typeof(TestClassNullable);
+            builder.EntitySet<TestClassNullable>(entitySetName);
+
+            ActAndAssertPropertyNullability(propertyName, edmType, expectedNullable, builder, entitySetName, type);
+        }
+
+        [Theory]
+        [InlineData(nameof(TestClassNullableContext.NonNullable), EdmPrimitiveTypeKind.String, false)]
+        [InlineData(nameof(TestClassNullableContext.Nullable), EdmPrimitiveTypeKind.String, true)]
+        [InlineData(nameof(TestClassNullableContext.NonNullablePropertyMaybeNull), EdmPrimitiveTypeKind.String, true)]
+        [InlineData(nameof(TestClassNullableContext.NonNullablePropertyAllowNull), EdmPrimitiveTypeKind.String, false)]
+        [InlineData(nameof(TestClassNullableContext.NullablePropertyNotNull), EdmPrimitiveTypeKind.String, true)]
+        [InlineData(nameof(TestClassNullableContext.NullablePropertyDisallowNull), EdmPrimitiveTypeKind.String, true)]
+        [InlineData(nameof(TestClassNullableContext.RequiredAndNullable), EdmPrimitiveTypeKind.String, false)]
+        [InlineData(nameof(TestClassNullableContext.NullObliviousNonNullable), EdmPrimitiveTypeKind.String, true)]
+        [InlineData(nameof(TestClassNullableContext.NullObliviousNullable), EdmPrimitiveTypeKind.String, true)]
+        public void Reference_nullability_with_context_sets_is_nullable_correctly(string propertyName, EdmPrimitiveTypeKind edmType, bool expectedNullable)
+        {
+            // Arrange         
+            var builder = new ODataConventionModelBuilder();
+            var entitySetName = nameof(TestClassNullableContext) + "s";
+            var type = typeof(TestClassNullableContext);
+            builder.EntitySet<TestClassNullableContext>(entitySetName);
+
+            ActAndAssertPropertyNullability(propertyName, edmType, expectedNullable, builder, entitySetName, type);
+        }
+
+        [Theory]
+        [InlineData(nameof(B.NonNullableValueType), EdmPrimitiveTypeKind.Guid, false)]
+        [InlineData(nameof(B.NullableValueType), EdmPrimitiveTypeKind.Guid, true)]
+        [InlineData(nameof(B.NonNullableRefType), EdmPrimitiveTypeKind.String, false)]
+        [InlineData(nameof(B.NullableRefType), EdmPrimitiveTypeKind.String, true)]
+        public void Value_ref_nullability_sets_is_nullable_correctly(string propertyName, EdmPrimitiveTypeKind edmType, bool expectedNullable)
+        {
+            // Arrange         
+            var builder = new ODataConventionModelBuilder();
+            var entitySetName = nameof(B) + "s";
+            var type = typeof(B);
+            builder.EntitySet<B>(entitySetName);
+
+            ActAndAssertPropertyNullability(propertyName, edmType, expectedNullable, builder, entitySetName, type);
+        }
+
+        [Theory]
+        [InlineData(nameof(DerivedClass.NonNullable), EdmPrimitiveTypeKind.String, false)]
+        [InlineData(nameof(DerivedClass.Nullable), EdmPrimitiveTypeKind.String, true)]
+        public void Reference_nullability_sets_is_nullable_correctlyDerivedClass(string propertyName, EdmPrimitiveTypeKind edmType, bool expectedNullable)
+        {
+            // Arrange         
+            var builder = new ODataConventionModelBuilder();
+            var entitySetName = nameof(DerivedClass) + "s";
+            var type = typeof(DerivedClass);
+            builder.EntitySet<DerivedClass>(entitySetName);
+
+            ActAndAssertPropertyNullability(propertyName, edmType, expectedNullable, builder, entitySetName, type);
+        }
+
+        [Theory]
+        [InlineData(nameof(DerivedClass.Nullable), EdmPrimitiveTypeKind.String, true)]
+        public void Reference_nullability_sets_is_nullable_correctlyBaseClass(string propertyName, EdmPrimitiveTypeKind edmType, bool expectedNullable)
+        {
+            // Arrange         
+            var builder = new ODataConventionModelBuilder();
+            var entitySetName = nameof(BaseClass) + "s";
+            var type = typeof(BaseClass);
+            builder.EntitySet<BaseClass>(entitySetName);
+
+            ActAndAssertPropertyNullability(propertyName, edmType, expectedNullable, builder, entitySetName, type);
+        }
+
+        private static void ActAndAssertPropertyNullability(string propertyName, EdmPrimitiveTypeKind edmType, bool expectedNullable, ODataConventionModelBuilder builder, string entitySetName, Type type)
+        {
+
+            // Act
+            var model = builder.GetEdmModel();
+
+            // Assert
+            model.AssertHasEntitySet(entitySetName, type);
+
+            var propertyEntity = model.AssertHasEntityType(type);
+            propertyEntity.AssertHasPrimitiveProperty(model, propertyName, edmType, isNullable: expectedNullable);
+        }
+
+        // Subset of tests used by EF Core
+        //     Field tests are not used by OData
+        //     Properties must have setter
+        // NullableContextAttribute(2)
+        // NullableAttribute(0)
+        private class TestClassNullable
+        {
+            public int Id { get; set; }
+
+#nullable enable
+            // NullableAttribute(1)
+            public string NonNullable { get; set; } = "";
+            public string? Nullable { get; set; }
+
+            // NullableAttribute(1)
+            [MaybeNull]
+            public string NonNullablePropertyMaybeNull { get; set; } = "";
+
+            // NullableAttribute(1)
+            [AllowNull]
+            public string NonNullablePropertyAllowNull { get; set; } = "";
+
+            [NotNull]
+            public string? NullablePropertyNotNull { get; set; } = "";
+
+            [DisallowNull]
+            public string? NullablePropertyDisallowNull { get; set; } = "";
+
+            [Required]
+            public string? RequiredAndNullable { get; set; }
+#nullable disable
+
+#pragma warning disable CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' context.
+            // NullableAttribute(0)
+            public string NullObliviousNonNullable { get; set; }
+            public string? NullObliviousNullable { get; set; }
+#pragma warning restore CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' context.
+        }
+
+        //
+        // Same as previous class TestClassNullable but add extra NonNullables to change the NullableContextAttribute
+        //
+        // NullableContextAttribute(1)
+        // NullableAttribute(0)
+        private class TestClassNullableContext
+        {
+            public int Id { get; set; }
+
+#nullable enable
+            public string NonNullable { get; set; } = "";
+            // NullableAttribute(2)
+            public string? Nullable { get; set; }
+
+            [MaybeNull]
+            public string NonNullablePropertyMaybeNull { get; set; } = "";
+
+            [AllowNull]
+            public string NonNullablePropertyAllowNull { get; set; } = "";
+
+            // NullableAttribute(2)
+            [NotNull]
+            public string? NullablePropertyNotNull { get; set; } = "";
+
+            // NullableAttribute(2)
+            [DisallowNull]
+            public string? NullablePropertyDisallowNull { get; set; } = "";
+
+            // NullableAttribute(2)
+            [Required]
+            public string? RequiredAndNullable { get; set; }
+
+            public string NonNullableProperty1 { get; set; } = "";
+            public string NonNullableProperty2 { get; set; } = "";
+
+#nullable disable
+
+#pragma warning disable CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' context.
+            // NullableAttribute(0)
+            public string NullObliviousNonNullable { get; set; }
+            // NullableAttribute(2)
+            public string? NullObliviousNullable { get; set; }
+#pragma warning restore CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' context.
+        }
+
+#nullable enable
+        public class B
+        {
+            [Key]
+            public Guid NonNullableValueType { get; set; }
+
+            public Guid? NullableValueType { get; set; }
+            public string NonNullableRefType { get; set; } = "";
+            public string? NullableRefType { get; set; }
+        }
+
+        public class DerivedClass : BaseClass
+        {
+            public string NonNullable { get; set; } = default!;
+        }
+
+        public class BaseClass
+        {
+            public int Id { get; set; }
+            public string? Nullable { get; set; }
+        }
+#nullable disable
+    }
+}

--- a/test/Microsoft.OData.ModelBuilder.Tests/PublicApi/PublicApiTest.cs
+++ b/test/Microsoft.OData.ModelBuilder.Tests/PublicApi/PublicApiTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using Xunit;
 
 namespace Microsoft.OData.ModelBuilder.Tests.PublicApi
@@ -35,12 +36,25 @@ namespace Microsoft.OData.ModelBuilder.Tests.PublicApi
             string baselineString = GetBaseLineString();
 
             // Assert
-            Assert.True(String.Compare(baselineString, outputString, StringComparison.Ordinal) == 0,
-                String.Format("Base line file {1} and output file {2} do not match, please check.{0}" +
-                "To update the baseline, please run:{0}{0}" +
-                "copy /y \"{2}\" \"{1}\"", Environment.NewLine,
-                BaseLineFileFolder + BaseLineFileName,
-                outputFile));
+            if (string.Compare(baselineString, outputString, StringComparison.Ordinal) != 0)
+            {
+                const int sliceSize = 128;
+
+                var diffPoint = baselineString.Zip(outputString, (c1, c2) => c1 == c2).TakeWhile(b => b).Count();
+
+                var displayBaseline = baselineString.SliceCenter(diffPoint, sliceSize);
+                var displayOutput = outputString.SliceCenter(diffPoint, sliceSize);
+
+                Assert.True(false,
+                    string.Format("Base line file {1} and output file {2} do not match, please check.{0}" +
+                    "Baseline:{0}\"{3}\"{0}" +
+                    "Output:  {0}\"{4}\"{0}{0}" +
+                    "To update the baseline, please run:{0}{0}" +
+                    "copy /y \"{2}\" \"{1}\"", Environment.NewLine,
+                    BaseLineFileFolder + BaseLineFileName,
+                    outputFile,
+                    displayBaseline, displayOutput));
+            }
         }
 
         private string GetBaseLineString()
@@ -63,6 +77,38 @@ namespace Microsoft.OData.ModelBuilder.Tests.PublicApi
                     return reader.ReadToEnd();
                 }
             }
+        }
+    }
+
+    static class TestStringExtensions
+    {
+        internal static string SliceCenter(this string text, int center, int width)
+        {
+            int start;
+
+            if (center < 0)
+            {
+                start = 0;
+                return string.Empty;
+            }
+
+            center = (center <= text.Length) ? center : text.Length;
+
+            start = center - (width / 2);
+            var length = width;
+
+            if (start < 0)
+            {
+                start = 0;
+                length = center + (width / 2);
+            }
+
+            if (start + length > text.Length)
+            {
+                length = text.Length - start;
+            }
+
+            return text.Substring(start, length);
         }
     }
 }

--- a/test/Microsoft.OData.ModelBuilder.Tests/TestModels/NonNullable/Address.cs
+++ b/test/Microsoft.OData.ModelBuilder.Tests/TestModels/NonNullable/Address.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+namespace Microsoft.OData.ModelBuilder.Tests.TestModels.NonNullable
+{
+#nullable enable
+    //
+    // All of the properties in this class will be set to NonNullable through the NullableContextAttribute
+    //
+    // NullableContextAttribute{1}
+    public class Address
+    {
+        public int HouseNumber { get; set; }
+        public string Street { get; set; } = string.Empty;
+        public string City { get; set; } = string.Empty;
+        public string State { get; set; } = string.Empty;
+        public ZipCode ZipCode { get; set; } = new ZipCode();
+        public string IgnoreThis { get; set; } = "IgnoreThis";
+    }
+#nullable restore
+}

--- a/test/Microsoft.OData.ModelBuilder.Tests/TestModels/NonNullable/Company.cs
+++ b/test/Microsoft.OData.ModelBuilder.Tests/TestModels/NonNullable/Company.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.OData.ModelBuilder.Tests.TestModels.NonNullable
+{
+#nullable enable
+    //
+    // Most of the properties in this class will be set to NonNullable through the NullableContextAttribute
+    //     Website         Nullable by annotation
+    //     Subsidiaries    Nullable by annotation
+    //
+    // NullableContextAttribute{1}
+    public class Company
+    {
+        public int CompanyId { get; set; }
+        public string CompanyName { get; set; } = string.Empty;
+        // NullableAttribute{2}
+        public string? Website { get; set; }
+        public Address HeadQuarterAddress { get; set; } = new Address();
+        [Singleton]
+        public Employee CEO { get; set; } = new Employee();
+        public int CEOID { get; set; }
+        public List<Employee> CompanyEmployees { get; set; } = new List<Employee>();
+        public List<Customer> Customers { get; set; } = new List<Customer>();
+        // NullableAttribute{2,1}
+        public List<Address>? Subsidiaries { get; set; }
+    }
+#nullable restore
+}

--- a/test/Microsoft.OData.ModelBuilder.Tests/TestModels/NonNullable/Customer.cs
+++ b/test/Microsoft.OData.ModelBuilder.Tests/TestModels/NonNullable/Customer.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.OData.ModelBuilder.Tests.TestModels.NonNullable
+{
+#nullable enable
+    //
+    // Most of the properties in this class will be set to NonNullable through the NullableContextAttribute
+    //     SharePrice      Nullable by annotation
+    //     StartDate       Nullable by annotation
+    //
+    // NullableContextAttribute{1}
+    public class Customer
+    {
+        public int CustomerId { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string City { get; set; } = string.Empty;
+        public Address Address { get; set; } = new Address();
+        public Address WorkAddress { get; set; } = new Address();
+        public string Website { get; set; } = string.Empty;
+        public string ShareSymbol { get; set; } = string.Empty;
+        public Decimal? SharePrice { get; set; }
+        public Company Company { get; set; } = new Company();
+        public List<Order> Orders { get; set; } = new List<Order>();
+        public List<string> Aliases { get; set; } = new List<string>();
+        public List<Address> Addresses { get; set; } = new List<Address>();
+        public Dictionary<string, object> DynamicProperties { get; set; } = new Dictionary<string, object>();
+        public DateTimeOffset? StartDate { get; set; }
+    }
+#nullable restore
+}

--- a/test/Microsoft.OData.ModelBuilder.Tests/TestModels/NonNullable/Employee.cs
+++ b/test/Microsoft.OData.ModelBuilder.Tests/TestModels/NonNullable/Employee.cs
@@ -1,0 +1,70 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace Microsoft.OData.ModelBuilder.Tests.TestModels.NonNullable
+{
+#nullable enable
+    //
+    // Most of the properties in this class will be set to NonNullable through the NullableContextAttribute
+    //     IsCeoOf         Nullable by annotation
+    //     VacationAddress NonNullable by RequiredAttribute
+    //
+    // NullableContextAttribute{1}
+    public class Employee
+    {
+        public int EmployeeID { get; set; }
+        public string EmployeeName { get; set; } = string.Empty;
+        public Decimal BaseSalary { get; set; }
+        public DateTimeOffset Birthday { get; set; }
+        // NullableAttribute{2,1}
+        public IList<Company>? IsCeoOf { get; set; }
+        public int WorkCompanyId { get; set; }
+        public Company WorkCompany { get; set; } = new Company();
+        [Singleton]
+        public Employee Boss { get; set; } = new Employee();
+        public Address HomeAddress { get; set; } = new Address();
+#nullable disable
+        [Required]
+        public Address VacationAddress { get; set; } = new Address();
+#nullable enable
+        // NullableAttribute{2,1}
+        public IList<Employee>? DirectReports { get; set; }
+    }
+
+    //
+    // Most of the properties in this class will be set to Nullable through the NullableContextAttribute
+    //     ExtraDraw       NonNullable as Value type
+    //     ExtraOffice     Nullable by annotaion
+    //
+    // NullableContextAttribute{2}
+    public class Manager : Employee
+    {
+        public Decimal ExtraDraw;
+        public Address? ExtraOffice { get; set; }
+    }
+
+    //
+    // All of the properties in this class will be set to NonNullable as they are Value types
+    //
+    // No NullableContextAttribute, no NullableAttribute
+    public class Engineer : Employee
+    {
+        public int Level { get; set; }
+        public Decimal YearEndBonus { get; set; }
+    }
+
+    //
+    // All of the properties in this class will be set to NonNullable through the NullableContextAttribute
+    //
+    // NullableContextAttribute{1}
+    public class SalesPerson : Employee
+    {
+        public Decimal Bonus { get; set; }
+        public IList<Customer> Customers { get; set; } = new List<Customer>();
+    }
+#nullable restore
+}

--- a/test/Microsoft.OData.ModelBuilder.Tests/TestModels/NonNullable/Order.cs
+++ b/test/Microsoft.OData.ModelBuilder.Tests/TestModels/NonNullable/Order.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.OData.ModelBuilder.Tests.TestModels.NonNullable
+{
+    //
+    // Most of the properties in this class will be set to NonNullable through the NullableContextAttribute
+    //     DeliveryDate    Nullable by annotation
+    //
+    // NullableContextAttribute{1}
+    public class Order
+    {
+        public int OrderId { get; set; }
+        public Customer Customer { get; set; }
+        public Decimal Cost { get; set; }
+        public Decimal Price { get; set; }
+        public DateTimeOffset OrderDate { get; set; }
+        public DateTimeOffset? DeliveryDate { get; set; }
+    }
+}

--- a/test/Microsoft.OData.ModelBuilder.Tests/TestModels/NonNullable/ZipCode.cs
+++ b/test/Microsoft.OData.ModelBuilder.Tests/TestModels/NonNullable/ZipCode.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+namespace Microsoft.OData.ModelBuilder.Tests.TestModels.NonNullable
+{
+#nullable enable
+    //
+    // Most of the properties in this class will be set to NonNullable through the NullableContextAttribute
+    //     Part2           Nullable by annotation
+    //
+    // NullableContextAttribute{1}
+    public class ZipCode
+    {
+        public string Part1 { get; set; } = string.Empty;
+        // NullableAttribute{2}
+        public string? Part2 { get; set; }
+    }
+
+    //
+    // Most of the properties in this class will be set to NonNullable through the NullableContextAttribute
+    //     RecursiveZipCode       Nullable by annotation
+    //
+    // NullableContextAttribute{1}
+    public class RecursiveZipCode
+    {
+        public string Part1 { get; set; } = string.Empty;
+        public string Part2 { get; set; } = string.Empty;
+        public RecursiveZipCode? Recursive { get; set; }
+    }
+#nullable restore
+}

--- a/test/Microsoft.OData.ModelBuilder.Tests/Types/ComplexTypeTest.cs
+++ b/test/Microsoft.OData.ModelBuilder.Tests/Types/ComplexTypeTest.cs
@@ -157,7 +157,7 @@ namespace Microsoft.OData.ModelBuilder.Tests.Types
             builder.ComplexType<BadOpenComplexType>();
 
             // Act & Assert
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1 || NET5_0
             ExceptionAssert.ThrowsArgument(() => builder.GetEdmModel(),
                 "propertyInfo",
                 "Found more than one dynamic property container in type 'BadOpenComplexType'. " +


### PR DESCRIPTION
Implement convention model builder support for NonNullable Reference Types

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issues #16, #15.*

### Description

Implements NonNullable Reference Types in the convention builder as described in detail of issue #16.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

Documentation needed similar to what exists in EF Core.
