### PR TITLE
chore: Updating the preprocessor usage to support future versions

### DIFF
--- a/src/Microsoft.OData.ModelBuilder/Commons/EdmLibHelpers.cs
+++ b/src/Microsoft.OData.ModelBuilder/Commons/EdmLibHelpers.cs
@@ -75,7 +75,7 @@ namespace Microsoft.OData.ModelBuilder
                 new KeyValuePair<Type, IEdmPrimitiveType>(typeof(TimeOfDay), GetPrimitiveType(EdmPrimitiveTypeKind.TimeOfDay)),
                 new KeyValuePair<Type, IEdmPrimitiveType>(typeof(TimeOfDay?), GetPrimitiveType(EdmPrimitiveTypeKind.TimeOfDay)),
 
-#if NET6_0
+#if NET6_0_OR_GREATER
                 new KeyValuePair<Type, IEdmPrimitiveType>(typeof(DateOnly), GetPrimitiveType(EdmPrimitiveTypeKind.Date)),
                 new KeyValuePair<Type, IEdmPrimitiveType>(typeof(DateOnly?), GetPrimitiveType(EdmPrimitiveTypeKind.Date)),
                 new KeyValuePair<Type, IEdmPrimitiveType>(typeof(TimeOnly), GetPrimitiveType(EdmPrimitiveTypeKind.TimeOfDay)),

--- a/src/Microsoft.OData.ModelBuilder/Types/StructuralTypeConfigurationOfTStructuralType.cs
+++ b/src/Microsoft.OData.ModelBuilder/Types/StructuralTypeConfigurationOfTStructuralType.cs
@@ -168,7 +168,7 @@ namespace Microsoft.OData.ModelBuilder
             return GetPrimitivePropertyConfiguration(propertyExpression, nullable: false) as PrecisionPropertyConfiguration;
         }
 
-#if NET6_0
+#if NET6_0_OR_GREATER
         /// <summary>
         /// Adds a <see cref="TimeOnly"/> primitive property to the EDM type.
         /// </summary>

--- a/test/Microsoft.OData.ModelBuilder.Tests/Commons/ExceptionAssert.cs
+++ b/test/Microsoft.OData.ModelBuilder.Tests/Commons/ExceptionAssert.cs
@@ -288,7 +288,7 @@ namespace Microsoft.OData.ModelBuilder.Tests.Commons
         {
             if (exceptionMessage != null)
             {
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
                 exceptionMessage = exceptionMessage + " (Parameter '" + paramName + "')";
 #else
                 exceptionMessage = exceptionMessage + "\r\nParameter name: " + paramName;
@@ -392,7 +392,7 @@ namespace Microsoft.OData.ModelBuilder.Tests.Commons
         /// <exception cref="ThrowsException">Thrown when an exception was not thrown, or when an exception of the incorrect type is thrown</exception>
         public static InvalidEnumArgumentException ThrowsInvalidEnumArgument(Action testCode, string paramName, int invalidValue, Type enumType, bool allowDerivedExceptions = false)
         {
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             string message = String.Format(CultureReplacer.DefaultCulture,
                                            "The value of argument '{0}' ({1}) is invalid for Enum type '{2}'. (Parameter '{0}')",
                                            paramName, invalidValue, enumType.Name);

--- a/test/Microsoft.OData.ModelBuilder.Tests/Containers/EntitySetConfigurationTest.cs
+++ b/test/Microsoft.OData.ModelBuilder.Tests/Containers/EntitySetConfigurationTest.cs
@@ -37,7 +37,7 @@ namespace Microsoft.OData.ModelBuilder.Tests.Containers
         [Fact]
         public void CtorThatTakesClrType_Throws_ArgumentNull_For_Name()
         {
-#if NETCOREAPP3_1 || NET6_0
+#if NETCOREAPP3_1_OR_GREATER
             ExceptionAssert.Throws<ArgumentException>(
                 () => new EntitySetConfiguration(modelBuilder: new ODataModelBuilder(), entityClrType: typeof(EntitySetConfigurationTest), name: null),
                 "The argument 'name' is null or empty. (Parameter 'name')");
@@ -73,7 +73,7 @@ namespace Microsoft.OData.ModelBuilder.Tests.Containers
         [Fact]
         public void CtorThatTakesEntityTypeConfiguration_Throws_ArgumentNull_For_Name()
         {
-#if NETCOREAPP3_1 || NET6_0
+#if NETCOREAPP3_1_OR_GREATER
             ExceptionAssert.Throws<ArgumentException>(
                 () => new EntitySetConfiguration(
                     modelBuilder: new ODataModelBuilder(),

--- a/test/Microsoft.OData.ModelBuilder.Tests/ODataConventionModelBuilderTest.cs
+++ b/test/Microsoft.OData.ModelBuilder.Tests/ODataConventionModelBuilderTest.cs
@@ -3370,7 +3370,7 @@ namespace Microsoft.OData.ModelBuilder.Tests
             Assert.Null(nonLengthType.MaxLength);
         }
 
-#if NET6_0
+#if NET6_0_OR_GREATER
 
         [Fact]
         public void CanConfig_DateOnly_TimeOnly_Correctly()

--- a/test/Microsoft.OData.ModelBuilder.Tests/ODataModelBuilderTest.cs
+++ b/test/Microsoft.OData.ModelBuilder.Tests/ODataModelBuilderTest.cs
@@ -955,7 +955,7 @@ namespace Microsoft.OData.ModelBuilder.Tests
             entity.Property(p => p.DurationProperty).Precision = 5;
             entity.Property(p => p.TimeOfDayProperty).Precision = 6;
             entity.Property(p => p.DateTimeOffsetProperty).Precision = 7;
-#if NET6_0
+#if NET6_0_OR_GREATER
             entity.Property(p => p.OnlyTime).Precision = 8;
 #endif
 
@@ -974,7 +974,7 @@ namespace Microsoft.OData.ModelBuilder.Tests
             Assert.Equal(6, timeOfDayType.Precision.Value);
             Assert.Equal(7, dateTimeOffsetType.Precision.Value);
 
-#if NET6_0
+#if NET6_0_OR_GREATER
             IEdmTemporalTypeReference timeOnlyType =
                 (IEdmTemporalTypeReference)edmEntityType.DeclaredProperties.First(p => p.Name.Equals("OnlyTime")).Type;
             Assert.Equal(8, timeOnlyType.Precision.Value);
@@ -1139,7 +1139,7 @@ namespace Microsoft.OData.ModelBuilder.Tests
 
             public byte[] BinaryProperty { get; set; }
 
-#if NET6_0
+#if NET6_0_OR_GREATER
             public TimeOnly OnlyTime { get; set; }
 #endif
         }

--- a/test/Microsoft.OData.ModelBuilder.Tests/PublicApi/PublicApiTest.cs
+++ b/test/Microsoft.OData.ModelBuilder.Tests/PublicApi/PublicApiTest.cs
@@ -12,7 +12,7 @@ namespace Microsoft.OData.ModelBuilder.Tests.PublicApi
     {
         private const string AssemblyName = "Microsoft.OData.ModelBuilder.dll";
 
-#if NET6_0
+#if NET6_0_OR_GREATER
         private const string BaseLineFileName = "Microsoft.OData.ModelBuilder.PublicApi.net60.bsl";
         private const string OutputFileName = "Microsoft.OData.ModelBuilder.PublicApi.net60.out";
 #else

--- a/test/Microsoft.OData.ModelBuilder.Tests/Types/ComplexTypeTest.cs
+++ b/test/Microsoft.OData.ModelBuilder.Tests/Types/ComplexTypeTest.cs
@@ -157,7 +157,7 @@ namespace Microsoft.OData.ModelBuilder.Tests.Types
             builder.ComplexType<BadOpenComplexType>();
 
             // Act & Assert
-#if NETCOREAPP3_1 || NET6_0
+#if NETCOREAPP3_1_OR_GREATER
             ExceptionAssert.ThrowsArgument(() => builder.GetEdmModel(),
                 "propertyInfo",
                 "Found more than one dynamic property container in type 'BadOpenComplexType'. " +

--- a/test/Microsoft.OData.ModelBuilder.Tests/Types/PrimitiveTypeTest.cs
+++ b/test/Microsoft.OData.ModelBuilder.Tests/Types/PrimitiveTypeTest.cs
@@ -67,7 +67,7 @@ namespace Microsoft.OData.ModelBuilder.Tests.Types
             Assert.Equal("Edm.Date", dateProperty.Type.FullName());
         }
 
-#if NET6_0
+#if NET6_0_OR_GREATER
         [Fact]
         public void Create_DateOnly_TimeOnly_PrimitiveProperty()
         {
@@ -186,7 +186,7 @@ namespace Microsoft.OData.ModelBuilder.Tests.Types
         public TimeSpan CreatedTime { get; set; }
         public TimeSpan? EndTime { get; set; }
 
-#if NET6_0
+#if NET6_0_OR_GREATER
         public DateOnly OnlyDate { get; set; }
         public TimeOnly OnlyTime { get; set; }
 #endif


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

None

### Description

With this PR, the use of `#if NET6_0` preprocessor instructions has been updated to remain compatible for future versions. As described in the article [OR_GREATER preprocessor symbols for TFMs](https://github.com/dotnet/designs/blob/main/accepted/2020/or-greater-defines/or-greater-defines.md), no additional customizations will be necessary with future .NET versions.

> - .NET 5 and later
>   - Applies to netX.Y and the NET symbol
>   - For example, net6.0 will define NET, NET6_0, NET6_0_OR_GREATER and NET5_0_OR_GREATER.
>   - This will also include the corresponding defines a .NET Core 3.1 successor would have gotten. For example, net5.0 will also define NETCOREAPP, NETCOREAPP3_1_OR_GREATER..NETCOREAPP1_0_OR_GREATER.
>   - This will neither define a NETCOREAPP5_0 nor NETCOREAPP5_0_OR_GREATER.

### Checklist (Uncheck if it is not completed)

- [x] ~*Test cases added*~ Not necessary, as only housekeeping changes
- [X] *Build and test with one-click build and test script passed*

### Additional work necessary

None
