### PR TITLE
LowerCamelCaser: Support Camel Casing for Enum Members

### DIFF
--- a/src/Microsoft.OData.ModelBuilder/LowerCamelCaser.cs
+++ b/src/Microsoft.OData.ModelBuilder/LowerCamelCaser.cs
@@ -60,6 +60,29 @@ namespace Microsoft.OData.ModelBuilder
                     }
                 }
             }
+
+            if(_options.HasFlag(NameResolverOptions.ProcessEnumMemberNames))
+                ApplyEnumLowerCamelCase(builder);
+        }
+
+        /// <summary>
+        /// Applies lower camel case to Enum Members
+        /// </summary>
+        /// <param name="builder">The <see cref="ODataConventionModelBuilder"/> to be applied on.</param>
+        public void ApplyEnumLowerCamelCase(ODataConventionModelBuilder builder)
+        {
+            if (builder == null)
+            {
+                throw Error.ArgumentNull(nameof(builder));
+            }
+
+            foreach (EnumTypeConfiguration typeConfiguration in builder.EnumTypes)
+            {
+                foreach (EnumMemberConfiguration property in typeConfiguration.Members)
+                {
+                    property.Name = this.ToLowerCamelCase(property.Name);
+                }
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.OData.ModelBuilder/LowerCamelCaser.cs
+++ b/src/Microsoft.OData.ModelBuilder/LowerCamelCaser.cs
@@ -61,26 +61,14 @@ namespace Microsoft.OData.ModelBuilder
                 }
             }
 
-            if(_options.HasFlag(NameResolverOptions.ProcessEnumMemberNames))
-                ApplyEnumLowerCamelCase(builder);
-        }
-
-        /// <summary>
-        /// Applies lower camel case to Enum Members
-        /// </summary>
-        /// <param name="builder">The <see cref="ODataConventionModelBuilder"/> to be applied on.</param>
-        public void ApplyEnumLowerCamelCase(ODataConventionModelBuilder builder)
-        {
-            if (builder == null)
+            if (_options.HasFlag(NameResolverOptions.ProcessEnumMemberNames))
             {
-                throw Error.ArgumentNull(nameof(builder));
-            }
-
-            foreach (EnumTypeConfiguration typeConfiguration in builder.EnumTypes)
-            {
-                foreach (EnumMemberConfiguration property in typeConfiguration.Members)
+                foreach (EnumTypeConfiguration typeConfiguration in builder.EnumTypes)
                 {
-                    property.Name = this.ToLowerCamelCase(property.Name);
+                    foreach (EnumMemberConfiguration property in typeConfiguration.Members)
+                    {
+                        property.Name = this.ToLowerCamelCase(property.Name);
+                    }
                 }
             }
         }

--- a/src/Microsoft.OData.ModelBuilder/Microsoft.OData.ModelBuilder.xml
+++ b/src/Microsoft.OData.ModelBuilder/Microsoft.OData.ModelBuilder.xml
@@ -2353,6 +2353,12 @@
             </summary>
             <param name="builder">The <see cref="T:Microsoft.OData.ModelBuilder.ODataConventionModelBuilder"/> to be applied on.</param>
         </member>
+        <member name="M:Microsoft.OData.ModelBuilder.LowerCamelCaser.ApplyEnumLowerCamelCase(Microsoft.OData.ModelBuilder.ODataConventionModelBuilder)">
+            <summary>
+            Applies lower camel case to Enum Members
+            </summary>
+            <param name="builder">The <see cref="T:Microsoft.OData.ModelBuilder.ODataConventionModelBuilder"/> to be applied on.</param>
+        </member>
         <member name="M:Microsoft.OData.ModelBuilder.LowerCamelCaser.ToLowerCamelCase(System.String)">
             <summary>
             Converts a <see cref="T:System.String"/> to lower camel case.
@@ -2380,6 +2386,11 @@
             <summary>
             Process explicit property names
             such as entityTypeConfiguration.Property(e => e.Key).Name="Id".
+            </summary>
+        </member>
+        <member name="F:Microsoft.OData.ModelBuilder.NameResolverOptions.ProcessEnumValues">
+            <summary>
+            Process Enum values
             </summary>
         </member>
         <member name="T:Microsoft.OData.ModelBuilder.ODataContext">

--- a/src/Microsoft.OData.ModelBuilder/Microsoft.OData.ModelBuilder.xml
+++ b/src/Microsoft.OData.ModelBuilder/Microsoft.OData.ModelBuilder.xml
@@ -2481,6 +2481,17 @@
             <param name="builder">The <see cref="T:Microsoft.OData.ModelBuilder.ODataConventionModelBuilder"/> to be enabled with lower camel case.</param>
             <returns>Returns itself so that multiple calls can be chained.</returns>
         </member>
+        <member name="M:Microsoft.OData.ModelBuilder.ODataConventionModelBuilderExtensions.EnableLowerCamelCaseForPropertiesAndEnums(Microsoft.OData.ModelBuilder.ODataConventionModelBuilder)">
+            <summary>
+            Enable lower camel case with default <see cref="T:Microsoft.OData.ModelBuilder.NameResolverOptions"/>
+            NameResolverOptions.ProcessReflectedPropertyNames |
+            NameResolverOptions.ProcessDataMemberAttributePropertyNames |
+            NameResolverOptions.ProcessExplicitPropertyNames |
+            NameResolverOptions.ProcessEnumMemberNames
+            </summary>
+            <param name="builder">The <see cref="T:Microsoft.OData.ModelBuilder.ODataConventionModelBuilder"/> to be enabled with lower camel case.</param>
+            <returns>Returns itself so that multiple calls can be chained.</returns>
+        </member>
         <member name="M:Microsoft.OData.ModelBuilder.ODataConventionModelBuilderExtensions.EnableLowerCamelCase(Microsoft.OData.ModelBuilder.ODataConventionModelBuilder,Microsoft.OData.ModelBuilder.NameResolverOptions)">
             <summary>
             Enable lower camel case with given <see cref="T:Microsoft.OData.ModelBuilder.NameResolverOptions"/>.

--- a/src/Microsoft.OData.ModelBuilder/Microsoft.OData.ModelBuilder.xml
+++ b/src/Microsoft.OData.ModelBuilder/Microsoft.OData.ModelBuilder.xml
@@ -2353,12 +2353,6 @@
             </summary>
             <param name="builder">The <see cref="T:Microsoft.OData.ModelBuilder.ODataConventionModelBuilder"/> to be applied on.</param>
         </member>
-        <member name="M:Microsoft.OData.ModelBuilder.LowerCamelCaser.ApplyEnumLowerCamelCase(Microsoft.OData.ModelBuilder.ODataConventionModelBuilder)">
-            <summary>
-            Applies lower camel case to Enum Members
-            </summary>
-            <param name="builder">The <see cref="T:Microsoft.OData.ModelBuilder.ODataConventionModelBuilder"/> to be applied on.</param>
-        </member>
         <member name="M:Microsoft.OData.ModelBuilder.LowerCamelCaser.ToLowerCamelCase(System.String)">
             <summary>
             Converts a <see cref="T:System.String"/> to lower camel case.
@@ -2388,9 +2382,9 @@
             such as entityTypeConfiguration.Property(e => e.Key).Name="Id".
             </summary>
         </member>
-        <member name="F:Microsoft.OData.ModelBuilder.NameResolverOptions.ProcessEnumValues">
+        <member name="F:Microsoft.OData.ModelBuilder.NameResolverOptions.ProcessEnumMemberNames">
             <summary>
-            Process Enum values
+            Process Member Name in Enum
             </summary>
         </member>
         <member name="T:Microsoft.OData.ModelBuilder.ODataContext">

--- a/src/Microsoft.OData.ModelBuilder/NameResolverOptions.cs
+++ b/src/Microsoft.OData.ModelBuilder/NameResolverOptions.cs
@@ -26,6 +26,11 @@ namespace Microsoft.OData.ModelBuilder
         /// Process explicit property names
         /// such as entityTypeConfiguration.Property(e => e.Key).Name="Id".
         /// </summary>
-        ProcessExplicitPropertyNames = 4
+        ProcessExplicitPropertyNames = 4,
+
+        /// <summary>
+        /// Process Member Name in Enum
+        /// </summary>
+        ProcessEnumMemberNames = 8
     }
 }

--- a/src/Microsoft.OData.ModelBuilder/ODataConventionModelBuilderExtensions.cs
+++ b/src/Microsoft.OData.ModelBuilder/ODataConventionModelBuilderExtensions.cs
@@ -26,7 +26,9 @@ namespace Microsoft.OData.ModelBuilder
             return builder.EnableLowerCamelCase(
                 NameResolverOptions.ProcessReflectedPropertyNames |
                 NameResolverOptions.ProcessDataMemberAttributePropertyNames |
-                NameResolverOptions.ProcessExplicitPropertyNames);
+                NameResolverOptions.ProcessExplicitPropertyNames | 
+                NameResolverOptions.ProcessEnumMemberNames
+                );
         }
 
         /// <summary>

--- a/src/Microsoft.OData.ModelBuilder/ODataConventionModelBuilderExtensions.cs
+++ b/src/Microsoft.OData.ModelBuilder/ODataConventionModelBuilderExtensions.cs
@@ -26,7 +26,30 @@ namespace Microsoft.OData.ModelBuilder
             return builder.EnableLowerCamelCase(
                 NameResolverOptions.ProcessReflectedPropertyNames |
                 NameResolverOptions.ProcessDataMemberAttributePropertyNames |
-                NameResolverOptions.ProcessExplicitPropertyNames | 
+                NameResolverOptions.ProcessExplicitPropertyNames
+                );
+        }
+
+        /// <summary>
+        /// Enable lower camel case with default <see cref="NameResolverOptions"/>
+        /// NameResolverOptions.ProcessReflectedPropertyNames |
+        /// NameResolverOptions.ProcessDataMemberAttributePropertyNames |
+        /// NameResolverOptions.ProcessExplicitPropertyNames |
+        /// NameResolverOptions.ProcessEnumMemberNames
+        /// </summary>
+        /// <param name="builder">The <see cref="ODataConventionModelBuilder"/> to be enabled with lower camel case.</param>
+        /// <returns>Returns itself so that multiple calls can be chained.</returns>
+        public static ODataConventionModelBuilder EnableLowerCamelCaseForPropertiesAndEnums(this ODataConventionModelBuilder builder)
+        {
+            if (builder == null)
+            {
+                throw Error.ArgumentNull("builder");
+            }
+
+            return builder.EnableLowerCamelCase(
+                NameResolverOptions.ProcessReflectedPropertyNames |
+                NameResolverOptions.ProcessDataMemberAttributePropertyNames |
+                NameResolverOptions.ProcessExplicitPropertyNames |
                 NameResolverOptions.ProcessEnumMemberNames
                 );
         }

--- a/test/Microsoft.OData.ModelBuilder.Tests/LowerCamelCaserTest.cs
+++ b/test/Microsoft.OData.ModelBuilder.Tests/LowerCamelCaserTest.cs
@@ -135,6 +135,25 @@ namespace Microsoft.OData.ModelBuilder.Tests
             Assert.Single(lowerCamelCaserModelAliasEntity.Properties().Where(p => p.Name == "color"));
             Assert.Single(lowerCamelCaserModelAliasEntity.Properties().Where(p => p.Name == "Price"));
         }
+
+        [Fact]
+        public void LowerCamelCaser_ProcessEnumMemberNames()
+        {
+            // Arrange
+            var builder = ODataConventionModelBuilderFactory.Create().EnableLowerCamelCase(NameResolverOptions.ProcessEnumMemberNames);
+            EntityTypeConfiguration<LowerCamelCaserEnumEntity> entity = builder.EntitySet<LowerCamelCaserEnumEntity>("Entities").EntityType;
+
+            // Act
+            IEdmModel model = builder.GetEdmModel();
+
+            // Assert
+            IEdmEnumType lowerCamelCaserEnum =
+                Assert.Single(model.SchemaElements.OfType<IEdmEnumType>().Where(e => e.Name == "LowerCamelCaserEnum"));
+            Assert.Equal(EdmTypeKind.Enum, lowerCamelCaserEnum.TypeKind);
+            Assert.Equal(2, lowerCamelCaserEnum.Members.Count());
+            Assert.Single(lowerCamelCaserEnum.Members.Where(p => p.Name == "enumMember1"));
+            Assert.Single(lowerCamelCaserEnum.Members.Where(p => p.Name == "enumMember2"));
+        }
     }
 
     public class LowerCamelCaserEntity
@@ -169,5 +188,23 @@ namespace Microsoft.OData.ModelBuilder.Tests
         public Color Color { get; set; }
 
         public double Price { get; set; }
+    }
+
+    public class LowerCamelCaserEnumEntity
+    {
+        public enum LowerCamelCaserEnum
+        {
+            [EnumMember]
+            EnumMember1,
+
+            [EnumMember]
+            EnumMember2,
+        }
+
+        [DataMember]
+        public int Id { get; set; }
+
+        [DataMember]
+        public LowerCamelCaserEnum EnumProperty { get; set; }
     }
 }

--- a/test/Microsoft.OData.ModelBuilder.Tests/PublicApi/Microsoft.OData.ModelBuilder.PublicApi.bsl
+++ b/test/Microsoft.OData.ModelBuilder.Tests/PublicApi/Microsoft.OData.ModelBuilder.PublicApi.bsl
@@ -3,6 +3,7 @@ FlagsAttribute(),
 ]
 public enum Microsoft.OData.ModelBuilder.NameResolverOptions : int {
 	ProcessDataMemberAttributePropertyNames = 2
+	ProcessEnumMemberNames = 8
 	ProcessExplicitPropertyNames = 4
 	ProcessReflectedPropertyNames = 1
 }

--- a/test/Microsoft.OData.ModelBuilder.Tests/PublicApi/Microsoft.OData.ModelBuilder.PublicApi.bsl
+++ b/test/Microsoft.OData.ModelBuilder.Tests/PublicApi/Microsoft.OData.ModelBuilder.PublicApi.bsl
@@ -381,6 +381,11 @@ public sealed class Microsoft.OData.ModelBuilder.ODataConventionModelBuilderExte
 	ExtensionAttribute(),
 	]
 	public static Microsoft.OData.ModelBuilder.ODataConventionModelBuilder EnableLowerCamelCase (Microsoft.OData.ModelBuilder.ODataConventionModelBuilder builder, Microsoft.OData.ModelBuilder.NameResolverOptions options)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static Microsoft.OData.ModelBuilder.ODataConventionModelBuilder EnableLowerCamelCaseForPropertiesAndEnums (Microsoft.OData.ModelBuilder.ODataConventionModelBuilder builder)
 }
 
 [

--- a/test/Microsoft.OData.ModelBuilder.Tests/PublicApi/Microsoft.OData.ModelBuilder.PublicApi.net60.bsl
+++ b/test/Microsoft.OData.ModelBuilder.Tests/PublicApi/Microsoft.OData.ModelBuilder.PublicApi.net60.bsl
@@ -383,6 +383,11 @@ public sealed class Microsoft.OData.ModelBuilder.ODataConventionModelBuilderExte
 	ExtensionAttribute(),
 	]
 	public static Microsoft.OData.ModelBuilder.ODataConventionModelBuilder EnableLowerCamelCase (Microsoft.OData.ModelBuilder.ODataConventionModelBuilder builder, Microsoft.OData.ModelBuilder.NameResolverOptions options)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static Microsoft.OData.ModelBuilder.ODataConventionModelBuilder EnableLowerCamelCaseForPropertiesAndEnums (Microsoft.OData.ModelBuilder.ODataConventionModelBuilder builder)
 }
 
 [

--- a/test/Microsoft.OData.ModelBuilder.Tests/PublicApi/Microsoft.OData.ModelBuilder.PublicApi.net60.bsl
+++ b/test/Microsoft.OData.ModelBuilder.Tests/PublicApi/Microsoft.OData.ModelBuilder.PublicApi.net60.bsl
@@ -3,6 +3,7 @@ FlagsAttribute(),
 ]
 public enum Microsoft.OData.ModelBuilder.NameResolverOptions : int {
 	ProcessDataMemberAttributePropertyNames = 2
+	ProcessEnumMemberNames = 8
 	ProcessExplicitPropertyNames = 4
 	ProcessReflectedPropertyNames = 1
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes issue #[84.](https://github.com/OData/AspNetCoreOData/issues/84)

### Description

Objective of this PR is to enable EnumCamelCaser to support camel casing for Enum Members. In the current state, Enum Member is not camel cased when processed by LowerCamelCaser. The workaround is to use EnumMember attribute (specifying the EnumMember.Value in camel case) for each of the EnumMembers.

With this PR, support has been added to EnumCamelCaser to process the Enum Members. A new flag is added to NameResolverOptions (ProcessEnumMemberNames) that will define if the EnumMember should be camel cased. If the flag is enabled, then LowerCamelCaser.ApplyLowerCamelCase() will iterate though each of the Enum Members in Builder.EnumTypes and will convert the EnumMember's Name to Camel Case.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

Additional update to documentation may be needed for the new flag added to LowerCamelCaser.
