### PR TITLE
net6 DateOnly type compatability

### DIFF
--- a/src/Microsoft.OData.ModelBuilder/Commons/TypeHelper.cs
+++ b/src/Microsoft.OData.ModelBuilder/Commons/TypeHelper.cs
@@ -207,6 +207,17 @@ namespace Microsoft.OData.ModelBuilder
         }
 
         /// <summary>
+        /// Determine if a type is a DateOnly.
+        /// </summary>
+        /// <param name="clrType">The type to test.</param>
+        /// <returns>True if the type is a DateOnly; false otherwise.</returns>
+        public static bool IsDateOnly(Type clrType)
+        {
+            Type underlyingTypeOrSelf = GetUnderlyingTypeOrSelf(clrType);
+            return underlyingTypeOrSelf.FullName == "System.DateOnly";
+        }
+
+        /// <summary>
         /// Determine if a type is a TimeSpan.
         /// </summary>
         /// <param name="clrType">The type to test.</param>

--- a/src/Microsoft.OData.ModelBuilder/Microsoft.OData.ModelBuilder.xml
+++ b/src/Microsoft.OData.ModelBuilder/Microsoft.OData.ModelBuilder.xml
@@ -672,6 +672,13 @@
             <param name="clrType">The type to test.</param>
             <returns>True if the type is a DateTime; false otherwise.</returns>
         </member>
+        <member name="M:Microsoft.OData.ModelBuilder.TypeHelper.IsDateOnly(System.Type)">
+            <summary>
+            Determine if a type is a DateOnly.
+            </summary>
+            <param name="clrType">The type to test.</param>
+            <returns>True if the type is a DateOnly; false otherwise.</returns>
+        </member>
         <member name="M:Microsoft.OData.ModelBuilder.TypeHelper.IsTimeSpan(System.Type)">
             <summary>
             Determine if a type is a TimeSpan.
@@ -8340,28 +8347,7 @@
             </summary>
             <param name="description">The value to set</param>
             <returns><see cref="T:Microsoft.OData.ModelBuilder.Capabilities.V1.UpdateRestrictionsConfiguration"/></returns>
-        </member>
-        <member name="M:Microsoft.OData.ModelBuilder.Capabilities.V1.UpdateRestrictionsConfiguration.HasLongDescription(System.String)">
-            <summary>
-            A lengthy description of the request
-            </summary>
-            <param name="longDescription">The value to set</param>
-            <returns><see cref="T:Microsoft.OData.ModelBuilder.Capabilities.V1.UpdateRestrictionsConfiguration"/></returns>
-        </member>
-        <member name="M:Microsoft.OData.ModelBuilder.Capabilities.V1.UpdateRestrictionsConfiguration.ToEdmExpression">
-            <inheritdoc/>
-        </member>
-        <member name="T:Microsoft.OData.ModelBuilder.Core.V1.AcceptableMediaTypesConfiguration">
-            <summary>
-            Lists the MIME types acceptable for the annotated entity type marked with HasStream="true" or the annotated stream property
-            </summary>
-        </member>
-        <member name="P:Microsoft.OData.ModelBuilder.Core.V1.AcceptableMediaTypesConfiguration.TermName">
-            <inheritdoc/>
-        </member>
-        <member name="M:Microsoft.OData.ModelBuilder.Core.V1.AcceptableMediaTypesConfiguration.HasAcceptableMediaTypes(System.String[])">
-            <summary>
-            Lists the MIME types acceptable for the annotated entity type marked with HasStream="true" or the annotated stream property
+        </membererty
             </summary>
             <param name="acceptableMediaTypes">The value(s) to set</param>
             <returns><see cref="T:Microsoft.OData.ModelBuilder.Core.V1.AcceptableMediaTypesConfiguration"/></returns>
@@ -8406,6 +8392,28 @@
             <summary>
             Creates a new instance of <see cref="T:Microsoft.OData.ModelBuilder.Core.V1.AlternateKeyConfiguration"/>
             </summary>
+        </member>
+        <member name="M:Microsoft.OData.ModelBuilder.Core.V1.AlternateKeyConfiguration.HasDynamicProperty(System.String,System.Object)">
+            <summary>
+            Dynamic properties.
+            </summary>
+            <param name="name">The name to set</param>
+            <param name="value">The value to set</param>
+            <returns><see cref="T:Microsoft.OData.ModelBuilder.Core.V1.AlternateKeyConfiguration"/></returns>
+        </member>
+        <member name="M:Microsoft.OData.ModelBuilder.Core.V1.AlternateKeyConfiguration.HasKey(System.Func{Microsoft.OData.ModelBuilder.Core.V1.PropertyRefConfiguration,Microsoft.OData.ModelBuilder.Core.V1.PropertyRefConfiguration})">
+            <summary>
+            The set of properties that make up this key
+            </summary>
+            <param name="keyConfiguration">The configuration to set</param>
+            <returns><see cref="T:Microsoft.OData.ModelBuilder.Core.V1.AlternateKeyConfiguration"/></returns>
+        </member>
+        <member name="M:Microsoft.OData.ModelBuilder.Core.V1.AlternateKeyConfiguration.HasKey(Microsoft.OData.ModelBuilder.Core.V1.PropertyRefConfiguration[])">
+            <summary>
+            The set of properties that make up this key
+            </summary>
+            <param name="key">The value(s) to set</param>
+       y>
         </member>
         <member name="M:Microsoft.OData.ModelBuilder.Core.V1.AlternateKeyConfiguration.HasDynamicProperty(System.String,System.Object)">
             <summary>
@@ -9236,34 +9244,7 @@
         <member name="P:Microsoft.OData.ModelBuilder.Core.V1.OrderedConfiguration.TermName">
             <inheritdoc/>
         </member>
-        <member name="M:Microsoft.OData.ModelBuilder.Core.V1.OrderedConfiguration.HasDynamicProperty(System.String,System.Object)">
-            <summary>
-            Dynamic properties.
-            </summary>
-            <param name="name">The name to set</param>
-            <param name="value">The value to set</param>
-            <returns><see cref="T:Microsoft.OData.ModelBuilder.Core.V1.OrderedConfiguration"/></returns>
-        </member>
-        <member name="M:Microsoft.OData.ModelBuilder.Core.V1.OrderedConfiguration.IsOrdered(System.Boolean)">
-            <summary>
-            Collection has a stable order. Ordered collections of primitive or complex types can be indexed by ordinal.
-            </summary>
-            <param name="ordered">The value to set</param>
-            <returns><see cref="T:Microsoft.OData.ModelBuilder.Core.V1.OrderedConfiguration"/></returns>
-        </member>
-        <member name="M:Microsoft.OData.ModelBuilder.Core.V1.OrderedConfiguration.ToEdmExpression">
-            <inheritdoc/>
-        </member>
-        <member name="T:Microsoft.OData.ModelBuilder.Core.V1.Permission">
-            <summary>
-            Org.OData.Core.V1.Permission
-            </summary>
-        </member>
-        <member name="F:Microsoft.OData.ModelBuilder.Core.V1.Permission.None">
-            <summary>
-            No permissions
-            </summary>
-        </member>
+        <member name="M:Microsoft.OData.ModelBu/member>
         <member name="F:Microsoft.OData.ModelBuilder.Core.V1.Permission.Read">
             <summary>
             Read permission
@@ -9321,6 +9302,30 @@
         <member name="M:Microsoft.OData.ModelBuilder.Core.V1.PositionalInsertConfiguration.IsPositionalInsert(System.Boolean)">
             <summary>
             Items can be inserted at a given ordinal index.
+            </summary>
+            <param name="positionalInsert">The value to set</param>
+            <returns><see cref="T:Microsoft.OData.ModelBuilder.Core.V1.PositionalInsertConfiguration"/></returns>
+        </member>
+        <member name="M:Microsoft.OData.ModelBuilder.Core.V1.PositionalInsertConfiguration.ToEdmExpression">
+            <inheritdoc/>
+        </member>
+        <member name="T:Microsoft.OData.ModelBuilder.Core.V1.PrimitiveExampleValueConfiguration">
+            <summary>
+            Org.OData.Core.V1.PrimitiveExampleValue
+            </summary>
+        </member>
+        <member name="M:Microsoft.OData.ModelBuilder.Core.V1.PrimitiveExampleValueConfiguration.#ctor">
+            <summary>
+            Creates a new instance of <see cref="T:Microsoft.OData.ModelBuilder.Core.V1.PrimitiveExampleValueConfiguration"/>
+            </summary>
+        </member>
+        <member name="M:Microsoft.OData.ModelBuilder.Core.V1.PrimitiveExampleValueConfiguration.HasDynamicProperty(System.String,System.Object)">
+            <summary>
+            Dynamic properties.
+            </summary>
+            <param name="name">The name to set</param>
+            <param name="value">The value to set</param>
+            <returns><see cref="T:Microsoft.OData.ModelBuilder.Core.V1.PrimitiveExampleValueConfiguration"/></returns>ex.
             </summary>
             <param name="positionalInsert">The value to set</param>
             <returns><see cref="T:Microsoft.OData.ModelBuilder.Core.V1.PositionalInsertConfiguration"/></returns>
@@ -9454,31 +9459,7 @@
             <param name="info">The value to set</param>
             <returns><see cref="T:Microsoft.OData.ModelBuilder.Core.V1.ResourceExceptionConfiguration"/></returns>
         </member>
-        <member name="M:Microsoft.OData.ModelBuilder.Core.V1.ResourceExceptionConfiguration.HasretryLink(System.String)">
-            <summary>
-            A GET request to this URL retries retrieving the problematic instance
-            </summary>
-            <param name="retryLink">The value to set</param>
-            <returns><see cref="T:Microsoft.OData.ModelBuilder.Core.V1.ResourceExceptionConfiguration"/></returns>
-        </member>
-        <member name="M:Microsoft.OData.ModelBuilder.Core.V1.ResourceExceptionConfiguration.ToEdmExpression">
-            <inheritdoc/>
-        </member>
-        <member name="T:Microsoft.OData.ModelBuilder.Core.V1.ResourcePathConfiguration">
-            <summary>
-            Resource path for entity container child, can be relative to xml:base and the request URL
-            </summary>
-        </member>
-        <member name="P:Microsoft.OData.ModelBuilder.Core.V1.ResourcePathConfiguration.TermName">
-            <inheritdoc/>
-        </member>
-        <member name="M:Microsoft.OData.ModelBuilder.Core.V1.ResourcePathConfiguration.HasDynamicProperty(System.String,System.Object)">
-            <summary>
-            Dynamic properties.
-            </summary>
-            <param name="name">The name to set</param>
-            <param name="value">The value to set</param>
-            <returns><see cref="T:Microsoft.OData.ModelBuilder.Core.V1.ResourcePathConfiguration"/></returns>
+        <member name="M:Microsoft.OData.ModelBuilder.Core.V1.ResourceExceptionConfigurns>
         </member>
         <member name="M:Microsoft.OData.ModelBuilder.Core.V1.ResourcePathConfiguration.HasResourcePath(System.String)">
             <summary>
@@ -9976,6 +9957,21 @@
         </member>
         <member name="M:Microsoft.OData.ModelBuilder.VocabularyTermConfigurationExtensions.HasDescription``1(Microsoft.OData.ModelBuilder.StructuralTypeConfiguration{``0})">
             <summary>
+            <see cref="T:Microsoft.OData.ModelBuilder.Core.V1.DescriptionConfiguration"/> configuration
+            </summary>
+            <typeparam name="T">The type of the structured type.</typeparam>
+            <param name="structuredType">The <see cref="T:Microsoft.OData.Edm.IEdmStructuredType"/> that can be built using <see cref="T:Microsoft.OData.ModelBuilder.ODataModelBuilder"/>.</param>
+            <returns><see cref="T:Microsoft.OData.ModelBuilder.Core.V1.DescriptionConfiguration"/></returns>
+        </member>
+        <member name="M:Microsoft.OData.ModelBuilder.VocabularyTermConfigurationExtensions.HasLongDescription``1(Microsoft.OData.ModelBuilder.NavigationSourceConfiguration{``0})">
+            <summary>
+            <see cref="T:Microsoft.OData.ModelBuilder.Core.V1.LongDescriptionConfiguration"/> configuration
+            </summary>
+            <typeparam name="TEntity">The entity type of the navigation source.</typeparam>
+            <param name="navigationSource">The <see cref="T:Microsoft.OData.Edm.IEdmNavigationSource"/> that can be built using <see cref="T:Microsoft.OData.ModelBuilder.ODataModelBuilder"/>.</param>
+            <returns><see cref="T:Microsoft.OData.ModelBuilder.Core.V1.LongDescriptionConfiguration"/></returns>
+        </member>
+        <member name="M:Microsoft.OData.ModelBuilder.Vocabulary>
             <see cref="T:Microsoft.OData.ModelBuilder.Core.V1.DescriptionConfiguration"/> configuration
             </summary>
             <typeparam name="T">The type of the structured type.</typeparam>

--- a/src/Microsoft.OData.ModelBuilder/Property/PrimitivePropertyConfigurationExtensions.cs
+++ b/src/Microsoft.OData.ModelBuilder/Property/PrimitivePropertyConfigurationExtensions.cs
@@ -23,7 +23,7 @@ namespace Microsoft.OData.ModelBuilder
                 throw Error.ArgumentNull("property");
             }
 
-            if (!TypeHelper.IsDateTime(property.RelatedClrType))
+            if (!TypeHelper.IsDateTime(property.RelatedClrType) && !TypeHelper.IsDateOnly(property.RelatedClrType))
             {
                 throw Error.Argument("property", SRResources.MustBeDateTimeProperty, property.PropertyInfo.Name,
                     property.DeclaringType.FullName);

--- a/src/Microsoft.OData.ModelBuilder/SRResources.Designer.cs
+++ b/src/Microsoft.OData.ModelBuilder/SRResources.Designer.cs
@@ -448,7 +448,7 @@ namespace Microsoft.OData.ModelBuilder {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The property &apos;{0}&apos; on type &apos;{1}&apos; must be a System.DateTime property..
+        ///   Looks up a localized string similar to The property &apos;{0}&apos; on type &apos;{1}&apos; must be a System.DateTime or System.DateOnly property..
         /// </summary>
         internal static string MustBeDateTimeProperty {
             get {

--- a/src/Microsoft.OData.ModelBuilder/SRResources.resx
+++ b/src/Microsoft.OData.ModelBuilder/SRResources.resx
@@ -1,103 +1,122 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-    <!-- 
-        Microsoft ResX Schema
-
-        Version 1.3
-
-        The primary goals of this format is to allow a simple XML format 
-        that is mostly human readable. The generation and parsing of the 
-        various data types are done through the TypeConverter classes 
-        associated with the data types.
-
-        Example:
+  <!-- 
+    Microsoft ResX Schema 
     
-        ... ado.net/XML headers & schema ...
-        <resheader name="resmimetype">text/microsoft-resx</resheader>
-        <resheader name="version">1.3</resheader>
-        <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
-        <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
-        <data name="Name1">this is my long string</data>
-        <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
-        <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
-            [base64 mime encoded serialized .NET Framework object]
-        </data>
-        <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-            [base64 mime encoded string representing a byte array form of the .NET Framework object]
-        </data>
-
-        There are any number of "resheader" rows that contain simple 
-        name/value pairs.
-
-        Each data row contains a name, and value. The row also contains a 
-        type or mimetype. Type corresponds to a .NET class that support 
-        text/value conversion through the TypeConverter architecture. 
-        Classes that don't support this are serialized and stored with the 
-        mimetype set.
-
-        The mimetype is used for serialized objects, and tells the 
-        ResXResourceReader how to depersist the object. This is currently not 
-        extensible. For a given mimetype the value must be set accordingly:
-
-        Note - application/x-microsoft.net.object.binary.base64 is the format 
-        that the ResXResourceWriter will generate, however the reader can 
-        read any of the formats listed below.
-
-        mimetype: application/x-microsoft.net.object.binary.base64
-        value   : The object must be serialized with 
-            : System.Serialization.Formatters.Binary.BinaryFormatter
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
-        mimetype: application/x-microsoft.net.object.soap.base64
-        value   : The object must be serialized with 
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
-        mimetype: application/x-microsoft.net.object.bytearray.base64
-        value   : The object must be serialized into a byte array 
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-    
-    <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-        <xsd:element name="root" msdata:IsDataSet="true">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
             <xsd:complexType>
-                <xsd:choice maxOccurs="unbounded">
-                    <xsd:element name="data">
-                        <xsd:complexType>
-                            <xsd:sequence>
-                                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-                                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
-                            </xsd:sequence>
-                            <xsd:attribute name="name" type="xsd:string" msdata:Ordinal="1" />
-                            <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
-                            <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
-                        </xsd:complexType>
-                    </xsd:element>
-                    <xsd:element name="resheader">
-                        <xsd:complexType>
-                            <xsd:sequence>
-                                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-                            </xsd:sequence>
-                            <xsd:attribute name="name" type="xsd:string" use="required" />
-                        </xsd:complexType>
-                    </xsd:element>
-                </xsd:choice>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
-        </xsd:element>
-    </xsd:schema>
-    <resheader name="resmimetype">
-        <value>text/microsoft-resx</value>
-    </resheader>
-    <resheader name="version">
-        <value>1.3</value>
-    </resheader>
-    <resheader name="reader">
-        <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-    </resheader>
-    <resheader name="writer">
-        <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-    </resheader>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
   <data name="ArgumentMustBeGreaterThanOrEqualTo" xml:space="preserve">
     <value>Value must be greater than or equal to {0}.</value>
   </data>
@@ -246,7 +265,7 @@
     <value>The property '{0}' on type '{1}' must be a System.Object property.</value>
   </data>
   <data name="MustBeDateTimeProperty" xml:space="preserve">
-    <value>The property '{0}' on type '{1}' must be a System.DateTime property.</value>
+    <value>The property '{0}' on type '{1}' must be a System.DateTime or System.DateOnly property.</value>
   </data>
   <data name="MustBeTimeSpanProperty" xml:space="preserve">
     <value>The property '{0}' on type '{1}' must be a System.TimeSpan property.</value>

--- a/test/Microsoft.OData.ModelBuilder.Tests/Commons/TypeHelperTest.cs
+++ b/test/Microsoft.OData.ModelBuilder.Tests/Commons/TypeHelperTest.cs
@@ -211,6 +211,19 @@ namespace Microsoft.OData.ModelBuilder.Tests.Commons
             Assert.Equal(expected, TypeHelper.IsDateTime(type));
         }
 
+#if NET6_0_OR_GREATER
+        [Theory]
+        [InlineData(typeof(object), false)]
+        [InlineData(typeof(ICollection), false)]
+        [InlineData(typeof(DateTime), false)]
+        [InlineData(typeof(DateOnly), true)]
+        [InlineData(typeof(string), false)]
+        public void IsDateOnly(Type type, bool expected)
+        {
+            Assert.Equal(expected, TypeHelper.IsDateOnly(type));
+        }
+#endif
+
         [Theory]
         [InlineData(typeof(object), false)]
         [InlineData(typeof(ICollection), false)]


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes issue #30

https://github.com/OData/ModelBuilder/issues/30

### Description

Adds System.DateOnly compatibility 

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

