### PR TITLE
Update version to 2.0.0 and target ODL 8 and .NET 8.0

### DIFF
--- a/build/azure-pipelines-nightly.yml
+++ b/build/azure-pipelines-nightly.yml
@@ -63,10 +63,10 @@ extends:
             versionSpec: '>=5.2.0'
 
         - task: UseDotNet@2
-          displayName: Use .NET 6.0
+          displayName: Use .NET 8.0
           inputs:
             packageType: 'sdk'
-            version: '6.0.x'
+            version: '8.0.x'
 
         - task: Powershell@2
           displayName: 'Skip Strong Name Validation'

--- a/build/azure-pipelines-rolling.yml
+++ b/build/azure-pipelines-rolling.yml
@@ -11,6 +11,7 @@ trigger:
 # Pull request (PR) triggers
 pr:
 - main
+- release-1.x
 
 resources:
   repositories:
@@ -65,10 +66,10 @@ extends:
             checkLatest: true
 
         - task: UseDotNet@2
-          displayName: Use .NET 6.0
+          displayName: Use .NET 8.0
           inputs:
             packageType: 'sdk'
-            version: '6.0.x'
+            version: '8.0.x'
 
         - task: DotNetCoreCLI@2
           displayName: 'Build Microsoft.OData.ModelBuilder.csproj '

--- a/build/builder.versions.settings.targets
+++ b/build/builder.versions.settings.targets
@@ -1,15 +1,15 @@
 <Project>
   <!-- Set the version number: major, minor, build and release (i.e. alpha, beta or blank for RTM)-->
   <PropertyGroup>
-    <VersionMajor Condition="'$(VersionMajor)' == ''">1</VersionMajor>
+    <VersionMajor Condition="'$(VersionMajor)' == ''">2</VersionMajor>
     <VersionMinor Condition="'$(VersionMinor)' == ''">0</VersionMinor>
-    <VersionBuild Condition="'$(VersionBuild)' == ''">9</VersionBuild>
+    <VersionBuild Condition="'$(VersionBuild)' == ''">0</VersionBuild>
     <VersionRelease Condition="'$(VersionRelease)' == ''"></VersionRelease>
   </PropertyGroup>
   
     <!-- For NuGet Package Dependencies -->
   <PropertyGroup>
-    <ODataLibPackageDependency>[7.9.0, 8.0.0)</ODataLibPackageDependency>
+    <ODataLibPackageDependency>[8.0.0, 9.0.0)</ODataLibPackageDependency>
     <SystemComponentPackageDependency>[4.6.0,)</SystemComponentPackageDependency>
   </PropertyGroup>
 

--- a/src/Microsoft.OData.ModelBuilder/Annotations/NavigationSourceLinkBuilderAnnotation.cs
+++ b/src/Microsoft.OData.ModelBuilder/Annotations/NavigationSourceLinkBuilderAnnotation.cs
@@ -46,7 +46,7 @@ namespace Microsoft.OData.ModelBuilder
                 throw Error.ArgumentNull("model");
             }
 
-            IEdmEntityType elementType = navigationSource.EntityType();
+            IEdmEntityType elementType = navigationSource.EntityType;
             IEnumerable<IEdmEntityType> derivedTypes = model.FindAllDerivedTypes(elementType).Cast<IEdmEntityType>();
 
             //// Add navigation link builders for all navigation properties of entity.

--- a/src/Microsoft.OData.ModelBuilder/Commons/EdmLibHelpers.cs
+++ b/src/Microsoft.OData.ModelBuilder/Commons/EdmLibHelpers.cs
@@ -333,7 +333,7 @@ namespace Microsoft.OData.ModelBuilder
             }
 
             IList<IEdmStructuralProperty> results = new List<IEdmStructuralProperty>();
-            IEdmEntityType entityType = navigationSource.EntityType();
+            IEdmEntityType entityType = navigationSource.EntityType;
             IEdmVocabularyAnnotatable annotatable = navigationSource as IEdmVocabularyAnnotatable;
             if (annotatable != null)
             {

--- a/src/Microsoft.OData.ModelBuilder/Microsoft.OData.ModelBuilder.Nightly.nuspec
+++ b/src/Microsoft.OData.ModelBuilder/Microsoft.OData.ModelBuilder.Nightly.nuspec
@@ -15,12 +15,7 @@
     <icon>images\odata.png</icon>
     <repository type="git" url="https://github.com/OData/ModelBuilder.git" branch="master" />
     <dependencies>
-        <group targetFramework=".NET6.0">
-          <dependency id="Microsoft.OData.Edm" version="$ODataLibPackageDependency$" />
-          <dependency id="Microsoft.Spatial" version="$ODataLibPackageDependency$" />
-          <dependency id="System.ComponentModel.Annotations" version="$SystemComponentPackageDependency$" />
-        </group>
-        <group targetFramework=".NETStandard2.0">
+        <group targetFramework=".NET8.0">
           <dependency id="Microsoft.OData.Edm" version="$ODataLibPackageDependency$" />
           <dependency id="Microsoft.Spatial" version="$ODataLibPackageDependency$" />
           <dependency id="System.ComponentModel.Annotations" version="$SystemComponentPackageDependency$" />
@@ -28,12 +23,9 @@
       </dependencies>
   </metadata>
   <files>
-    <file src="$ProductRoot$\net6.0\Microsoft.OData.ModelBuilder.dll" target="lib\net6.0" />
-    <file src="$ProductRoot$\net6.0\Microsoft.OData.ModelBuilder.xml" target="lib\net6.0" />
-    <file src="$ProductRoot$\net6.0\Microsoft.OData.ModelBuilder.pdb" target="lib\net6.0" />
-    <file src="$ProductRoot$\netstandard2.0\Microsoft.OData.ModelBuilder.dll" target="lib\netstandard2.0" />
-    <file src="$ProductRoot$\netstandard2.0\Microsoft.OData.ModelBuilder.xml" target="lib\netstandard2.0" />
-    <file src="$ProductRoot$\netstandard2.0\Microsoft.OData.ModelBuilder.pdb" target="lib\netstandard2.0" />
+    <file src="$ProductRoot$\net8.0\Microsoft.OData.ModelBuilder.dll" target="lib\net8.0" />
+    <file src="$ProductRoot$\net8.0\Microsoft.OData.ModelBuilder.xml" target="lib\net8.0" />
+    <file src="$ProductRoot$\net8.0\Microsoft.OData.ModelBuilder.pdb" target="lib\net8.0" />
     <file src="$SourcesRoot$\images\odata.png" target="images\" />
   </files>
 </package>

--- a/src/Microsoft.OData.ModelBuilder/Microsoft.OData.ModelBuilder.Release.nuspec
+++ b/src/Microsoft.OData.ModelBuilder/Microsoft.OData.ModelBuilder.Release.nuspec
@@ -16,12 +16,7 @@
     <icon>images\odata.png</icon>
     <repository type="git" url="https://github.com/OData/ModelBuilder.git" branch="master" />
     <dependencies>
-      <group targetFramework=".NET6.0">
-        <dependency id="Microsoft.OData.Edm" version="$ODataLibPackageDependency$" />
-        <dependency id="Microsoft.Spatial" version="$ODataLibPackageDependency$" />
-        <dependency id="System.ComponentModel.Annotations" version="$SystemComponentPackageDependency$" />
-      </group>
-      <group targetFramework=".NETStandard2.0">
+      <group targetFramework=".NET8.0">
         <dependency id="Microsoft.OData.Edm" version="$ODataLibPackageDependency$" />
         <dependency id="Microsoft.Spatial" version="$ODataLibPackageDependency$" />
         <dependency id="System.ComponentModel.Annotations" version="$SystemComponentPackageDependency$" />
@@ -29,12 +24,9 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="$ProductRoot$\net6.0\Microsoft.OData.ModelBuilder.dll" target="lib\net6.0" />
-    <file src="$ProductRoot$\net6.0\Microsoft.OData.ModelBuilder.xml" target="lib\net6.0" />
-    <file src="$ProductRoot$\net6.0\Microsoft.OData.ModelBuilder.pdb" target="lib\net6.0" />
-    <file src="$ProductRoot$\netstandard2.0\Microsoft.OData.ModelBuilder.dll" target="lib\netstandard2.0" />
-    <file src="$ProductRoot$\netstandard2.0\Microsoft.OData.ModelBuilder.xml" target="lib\netstandard2.0" />
-    <file src="$ProductRoot$\netstandard2.0\Microsoft.OData.ModelBuilder.pdb" target="lib\netstandard2.0" />
+    <file src="$ProductRoot$\net8.0\Microsoft.OData.ModelBuilder.dll" target="lib\net8.0" />
+    <file src="$ProductRoot$\net8.0\Microsoft.OData.ModelBuilder.xml" target="lib\net8.0" />
+    <file src="$ProductRoot$\net8.0\Microsoft.OData.ModelBuilder.pdb" target="lib\net8.0" />
     <file src="$SourcesRoot$\images\odata.png" target="images\" />
   </files>
 </package>

--- a/src/Microsoft.OData.ModelBuilder/Microsoft.OData.ModelBuilder.csproj
+++ b/src/Microsoft.OData.ModelBuilder/Microsoft.OData.ModelBuilder.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <RootNamespace>Microsoft.OData.ModelBuilder</RootNamespace>
     <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
     
@@ -22,8 +22,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.OData.Edm" Version="7.9.0" />
-    <PackageReference Include="Microsoft.Spatial" Version="7.9.0" />
+    <PackageReference Include="Microsoft.OData.Edm" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Spatial" Version="8.0.1" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.6.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>

--- a/src/Microsoft.OData.ModelBuilder/ODataModelBuilder.cs
+++ b/src/Microsoft.OData.ModelBuilder/ODataModelBuilder.cs
@@ -632,10 +632,10 @@ namespace Microsoft.OData.ModelBuilder
             // The type of entity set should have key(s) defined.
             foreach (IEdmEntitySet entitySet in model.EntityContainer.Elements.OfType<IEdmEntitySet>())
             {
-                if (!entitySet.EntityType().Key().Any())
+                if (!entitySet.EntityType.Key().Any())
                 {
                     throw Error.InvalidOperation(SRResources.EntitySetTypeHasNoKeys, entitySet.Name,
-                        entitySet.EntityType().FullName());
+                        entitySet.EntityType.FullName());
                 }
             }
 

--- a/test/Microsoft.OData.ModelBuilder.Tests/Commons/EdmModelAsserts.cs
+++ b/test/Microsoft.OData.ModelBuilder.Tests/Commons/EdmModelAsserts.cs
@@ -16,9 +16,9 @@ namespace Microsoft.OData.ModelBuilder.Tests.Commons
             var entitySet = model.EntityContainer.EntitySets().Single(set => set.Name == entitySetName);
             Assert.NotNull(entitySet);
             Assert.Equal(entitySet.Name, entitySetName);
-            Assert.True(model.GetEdmType(mappedEntityClrType).IsEquivalentTo(entitySet.EntityType()));
+            Assert.True(model.GetEdmType(mappedEntityClrType).IsEquivalentTo(entitySet.EntityType));
 
-            return entitySet.EntityType();
+            return entitySet.EntityType;
         }
 
         public static IEdmEntityType AssertHasSingleton(this IEdmModel model, string singletonName, Type mappedEntityClrType)
@@ -28,9 +28,9 @@ namespace Microsoft.OData.ModelBuilder.Tests.Commons
             IEdmSingleton singleton = model.EntityContainer.FindSingleton(singletonName);
             Assert.NotNull(singleton);
             Assert.Equal(singletonName, singleton.Name);
-            Assert.True(model.GetEdmType(mappedEntityClrType).IsEquivalentTo(singleton.EntityType()));
+            Assert.True(model.GetEdmType(mappedEntityClrType).IsEquivalentTo(singleton.EntityType));
 
-            return singleton.EntityType();
+            return singleton.EntityType;
         }
 
         public static IEdmNavigationPropertyBinding AssertHasNavigationTarget(this IEdmNavigationSource navigationSource,

--- a/test/Microsoft.OData.ModelBuilder.Tests/Commons/MockType.cs
+++ b/test/Microsoft.OData.ModelBuilder.Tests/Commons/MockType.cs
@@ -85,7 +85,45 @@ namespace Microsoft.OData.ModelBuilder.Tests.Commons
             var mockPropertyInfo = new MockPropertyInfo(propertyType, propertyName);
             mockPropertyInfo.SetupGet(p => p.DeclaringType).Returns(this);
             mockPropertyInfo.SetupGet(p => p.ReflectedType).Returns(this);
+
+            // The model builder does checks custom property attributes to support some featuers ([Required], [Contained], etc.)
+            // So we have to mock the GetCustomAttributes methods. There are two overloads that we need worry about.
+            // - object[] GetCustomAttributes(bool inherit)
+            // - object[] GetCustomAttributes(Type attributeType, bool inherit)
+
+            // Let's start with the first overload. It should return all the attributes without
+            // filtering on type.
             mockPropertyInfo.Setup(p => p.GetCustomAttributes(It.IsAny<bool>())).Returns(attributes);
+
+            // The second overload is a bit more complicated. This overload is also called internally
+            // by extension methods like propertyInfo.GetCustomAttribute<T> or GetCustomAttributes<T>()
+            // The overload should only return attributes of the specified type.
+            // We should ensure that we also return an array of the specific attribute type, even if it's empty.
+            // For example, if we call property.GetCustomAttributes<MyAttribute>(), we should return
+            // an instance of MyAttribute[], not an instance of object[] or Attribute[] that only contains MyAttribute values.
+            // This should be the case even if the array is empty. Which means we should mock any possible Attribute type.
+            // This is important because MyAttribute[] can always be cast to Attribute[], but Attribute[] cannot always be cast to MyAttribute[]
+            // Returning the wrong type will cause .NET to throw invalid cast exceptions.
+
+            // We first start with a general catch-call case that returns an empty array of the input attribute type
+            // for any attribute type the method is called with.
+            mockPropertyInfo.Setup(p => p.GetCustomAttributes(It.IsAny<Type>(), It.IsAny<bool>()))
+                .Returns((Type attributeType, bool inherit) => Activator.CreateInstance(attributeType.MakeArrayType(), [0]) as object[]);
+
+            // Then for attributes that have been passed, we create specific mocks to handle their types and return corresponding arrays.
+            foreach (var attribute in attributes)
+            {
+                // Let's say attribute is of type MyAttribute, the following is equivalent of doing:
+                // MyAttribute[] attributeArray = new MyAttribute[] { attribute };
+                var attributeType = attribute.GetType();
+                var attributeArrayType = attributeType.MakeArrayType();
+                var attributeArray = (object[])Activator.CreateInstance(attributeArrayType, [1]); // Create array of length 1
+                attributeArray[0] = attribute;
+                // This assumes that the property only has one instance of each property type. We don't handle the case where
+                // the multiple attributes of the same type are applied to the same property. If we ever have such a use case
+                // we should probably avoid mocks and just defined real types to avoid complicating this method further.
+                mockPropertyInfo.Setup(p => p.GetCustomAttributes(It.Is<Type>(t => t == attributeType), It.IsAny<bool>())).Returns(attributeArray);
+            }
 
             _propertyInfos.Add(mockPropertyInfo);
 

--- a/test/Microsoft.OData.ModelBuilder.Tests/Containers/EntitySetTest.cs
+++ b/test/Microsoft.OData.ModelBuilder.Tests/Containers/EntitySetTest.cs
@@ -24,7 +24,7 @@ namespace Microsoft.OData.ModelBuilder.Tests.Containers
             Assert.NotNull(container);
             var customers = container.EntitySets().SingleOrDefault(e => e.Name == "Customers");
             Assert.NotNull(customers);
-            Assert.Equal("Customer", customers.EntityType().Name);
+            Assert.Equal("Customer", customers.EntityType.Name);
         }
 
         [Fact]

--- a/test/Microsoft.OData.ModelBuilder.Tests/Containers/SingletonTest.cs
+++ b/test/Microsoft.OData.ModelBuilder.Tests/Containers/SingletonTest.cs
@@ -130,7 +130,7 @@ namespace Microsoft.OData.ModelBuilder.Tests.Containers
 
             var osCorp = container.FindSingleton("OsCorp");
             Assert.NotNull(osCorp);
-            Assert.Equal("Company", osCorp.EntityType().Name);
+            Assert.Equal("Company", osCorp.EntityType.Name);
         }
 
         [Fact]
@@ -150,11 +150,11 @@ namespace Microsoft.OData.ModelBuilder.Tests.Containers
 
             var osCorp = container.FindSingleton("OsCorp");
             Assert.NotNull(osCorp);
-            Assert.Equal("Microsoft.OData.ModelBuilder.Tests.TestModels.Company", osCorp.EntityType().FullName());
+            Assert.Equal("Microsoft.OData.ModelBuilder.Tests.TestModels.Company", osCorp.EntityType.FullName());
 
             var companies = container.FindEntitySet("Companies");
             Assert.NotNull(companies);
-            Assert.Equal(osCorp.EntityType().FullName(), companies.EntityType().FullName());
+            Assert.Equal(osCorp.EntityType.FullName(), companies.EntityType.FullName());
         }
 
         [Fact]

--- a/test/Microsoft.OData.ModelBuilder.Tests/Microsoft.OData.ModelBuilder.Tests.csproj
+++ b/test/Microsoft.OData.ModelBuilder.Tests/Microsoft.OData.ModelBuilder.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <AssemblyName>Microsoft.OData.ModelBuilder.Tests</AssemblyName>
     <RootNamespace>Microsoft.OData.ModelBuilder.Tests</RootNamespace>
 

--- a/test/Microsoft.OData.ModelBuilder.Tests/ODataModelBuilderTest.cs
+++ b/test/Microsoft.OData.ModelBuilder.Tests/ODataModelBuilderTest.cs
@@ -299,7 +299,7 @@ namespace Microsoft.OData.ModelBuilder.Tests
 
             var myOrders = container.FindEntitySet("MyOrders");
             Assert.NotNull(myOrders);
-            var edmMyOrder = myOrders.EntityType();
+            var edmMyOrder = myOrders.EntityType;
             Assert.Equal("MyOrder", edmMyOrder.Name);
             AssertHasContainment(edmMyOrder, model);
         }
@@ -326,7 +326,7 @@ namespace Microsoft.OData.ModelBuilder.Tests
 
             var myOrders = container.FindEntitySet("MyOrders");
             Assert.NotNull(myOrders);
-            var edmMyOrder = myOrders.EntityType();
+            var edmMyOrder = myOrders.EntityType;
             Assert.Equal("MyOrder", edmMyOrder.Name);
             AssertHasContainment(edmMyOrder, model);
         }
@@ -352,7 +352,7 @@ namespace Microsoft.OData.ModelBuilder.Tests
 
             var myOrders = container.FindEntitySet("MySpecialOrders");
             Assert.NotNull(myOrders);
-            var edmMyOrder = myOrders.EntityType();
+            var edmMyOrder = myOrders.EntityType;
             Assert.Equal("MySpecialOrder", edmMyOrder.Name);
             AssertHasContainment(edmMyOrder, model);
             AssertHasAdditionalContainment(edmMyOrder, model);
@@ -385,7 +385,7 @@ namespace Microsoft.OData.ModelBuilder.Tests
 
             var myOrders = container.FindEntitySet("MySpecialOrders");
             Assert.NotNull(myOrders);
-            var edmMyOrder = myOrders.EntityType();
+            var edmMyOrder = myOrders.EntityType;
             Assert.Equal("MySpecialOrder", edmMyOrder.Name);
             AssertHasContainment(edmMyOrder, model);
             AssertHasAdditionalContainment(edmMyOrder, model);
@@ -942,7 +942,7 @@ namespace Microsoft.OData.ModelBuilder.Tests
 
             // Assert
             Assert.Null(decimalType.Precision);
-            Assert.Equal(0, decimalType.Scale);
+            Assert.Null(decimalType.Scale);
             Assert.Null(stringType.MaxLength);
         }
 

--- a/test/Microsoft.OData.ModelBuilder.Tests/Types/EnumTypeTest.cs
+++ b/test/Microsoft.OData.ModelBuilder.Tests/Types/EnumTypeTest.cs
@@ -1183,7 +1183,7 @@ namespace Microsoft.OData.ModelBuilder.Tests.Types
             builder.EntitySet<EntityTypeWithEnumTypePropertyTestModel>("Entities");
             IEdmModel model = builder.GetEdmModel();
             IEdmEntitySet entitySet = model.EntityContainer.FindEntitySet("Entities");
-            return entitySet.EntityType();
+            return entitySet.EntityType;
         }
     }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

The version constraint excludes ODL 8.

This causes the following warning when you install `Microsoft.OData.ModelBuilder` alongside `Microsoft.OData.Edm` 8.0.0.

### Description

The PR changes the target framework to .NET 8 and ODL version to ODL 8.0.0.

It also made the following changes:
- Update test to expect the default scale value to be `null` instead of 0. The [default scale value was actually changed to null](https://github.com/OData/odata.net/pull/2346) in [ODL 7.11.0](https://github.com/OData/odata.net/compare/7.10.0...7.11.0). But ModelBuilder was still targeting ODL 7.9.0, so this issue was never caught.
- Replaced calls to the deprecated `EntityType()` extension method with the `EntityType` property
- Improved mocking logic to fix some failing tests that resulted from a breaking change in `GetCustomAttributes` that was introduced in .NET 7. This is a bit involved, so I'll explain that in detail below.

## Notes on property attribute mocking and failing tests

After I changed the target framework to .NET 8.0.0, 24 tests failed with an `InvalidCastException` error:
![image](https://github.com/user-attachments/assets/f421ca16-a5a5-406d-914c-112425130ed2)

The exception was thrown from this [statement](https://github.com/dotnet/runtime/blob/main/src/coreclr/System.Private.CoreLib/src/System/Attribute.CoreCLR.cs#L462) in .NET

![image](https://github.com/user-attachments/assets/da062196-44c5-44b0-802b-1132717e2b15)

This codepath is reached when we call a method like `propertyInfo.GetCustomAttribute<SomeAttributeType>()` or `propertyInfo.GetCustomAttributes<SomeAttributeType>()`.

And we're doing that a couple of places, like on [`ODataConventionModelBuilder`](https://github.com/OData/ModelBuilder/blob/main/src/Microsoft.OData.ModelBuilder/ODataConventionModelBuilder.cs#L594) class where we check presence of the `ContainedAttribute` to determine whether a navigation property is contained.

![image](https://github.com/user-attachments/assets/b39b6de3-7a6f-46d5-b0f0-0f7c4b6a537c)

### Why was the `InvalidCastException` being thrown?

The exception was being thrown because it so happens that the `element.GetCustomAttributes(attributeType, inherit)` was return an empty array of type `object[]`. And .NET was trying to cast that to `Attribute[]`. This cast fails and throws the exception.

### Why was the exception not thrown before changing the target to .NET 8.0.0?

Previously, our target frameworks were .NET standard 2.0 and .NET 6.0. Prior to .NET 7, the custom attribute code used to look like this

```c#
(element.GetCustomAttributes(attributeType, inherit) as Attribute[])!
```
Since this uses the `as` keyword is used for the cast, it returns `null` instead of throwing an exception when the cast fails.

2 years ago (i.e. .NET 7), [this PR](https://github.com/dotnet/runtime/pull/65237) changed the implementation to:

```c#
(Attribute[])element.GetCustomAttributes(attributeType, inherit)
```
which throws an exception if the cast fails.

### Why did`element.GetCustomAttributes(attributeType, inherit)` return an `object[]` array instead of `Attribute[]` array?

It so happens that in the tests that fail, the property info was not an actual `PropertyInfo`, but a mock. We use helper methods in [`MockType.cs`]((https://github.com/OData/ModelBuilder/blob/main/test/Microsoft.OData.ModelBuilder.Tests/Commons/MockType.cs) to mock `Type` and `PropertyInfo` instances for use in tests.

The [`MockType.Property()`](https://github.com/OData/ModelBuilder/blob/main/test/Microsoft.OData.ModelBuilder.Tests/Commons/MockType.cs#L83) method adds a mock property info to a type and is supposed to mock the inherited [`MemberInfo.GetCustomAttributes()`](https://learn.microsoft.com/en-us/dotnet/api/system.reflection.memberinfo.getcustomattributes?view=net-8.0) method as well.

It so happens this method has two overloads:
- `object[] GetCustomAttributes(bool inherit)` which is supposed to return all attributes regardless of the attribute type
- `object[] GetCustomAttributes(Type attributeType, bool inherit)` which should return only attributes of the specified type

Note that the declared return type of these methods is `object[]`. Despite the return type being so open, the excepted return type should be `Attribute[]` for the first overload and an array of the target attribute type for the other method.

It also so happens that only the first overload was being mocked:

![image](https://github.com/user-attachments/assets/5bd6f1db-bc02-4cbd-a65e-c51752d73d6d)

The second overload was not being mocked. If a method is not mocked, I think Moq (the mocking library we use) generates a mock method that returns a default instance of the declared return type, which in this case would be an empty array of type `object[]` (and not `Attribute[]`).

Coincidentally, the `GetCustomAttribute<T>()` and `GetCustomAttributes<T>()` extension methods called by ModelBuilder call the second `MemberInfo.GetCustomAttributes(Type attributeType, bool inherit)` overload. Which in the case of this mock, returns an empty `object[]` array, which the implementation attempts to cast to `Attribute[]` resulting in the `InvalidCastException`.

### If the overload was no mocked, then how did tests that tested against custom attributes like `RequiredAttribute` pass without issues before?

Yes, we do have some tests that verify that specific attributes are handled properly by the model builder, [like this one](https://github.com/OData/ModelBuilder/blob/main/test/Microsoft.OData.ModelBuilder.Tests/ODataConventionModelBuilderTest.cs#L2147)

![image](https://github.com/user-attachments/assets/cd22b26a-062c-4108-91f6-73c34b56af20)

It so happens that some parts of model builder call `propertyInfo.GetCustomAttributes()` and then perform a filter on the result (e.g. `GetCustomAttributes().OfType<T>()`, and other parts call `proptertyInfo.GetCustomAttribute<T>()`. Code that use the first variant was not affected because they used the overload that was already mocked.

I also noticed that after introducing the fix, I didn't get failing tests that tested the `ContainedAttribute`. Yet this was one of the code paths leading to the failing tests. I realized that existing tests that tested the ContainedAttribute did not use the mock approach, but used real types that had the `Contained` attribute applied to some properties. Since they did not use the mock, they were not affected by the breaking change.

To make the sure the fix to the mocking logic works, I added a test that verifies the behaviour of the `Contained` attribute using mocks.

But my main take away is that we should avoid relying on mocks for types that are used in ways we do not control or that can be changed in ways we cannot predict.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*