### PR TITLE
Add README to NuGet package

### DIFF
--- a/src/Microsoft.OData.ModelBuilder/Microsoft.OData.ModelBuilder.csproj
+++ b/src/Microsoft.OData.ModelBuilder/Microsoft.OData.ModelBuilder.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net8.0</TargetFrameworks>
     <RootNamespace>Microsoft.OData.ModelBuilder</RootNamespace>
     <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
-	<PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     
     <!-- Let's generate our own assembly info -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
@@ -43,7 +43,7 @@
   </ItemGroup>
 
   <ItemGroup>
-	<None Include="README.md" Pack="true" PackagePath="\"/>
+    <None Include="README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.OData.ModelBuilder/Microsoft.OData.ModelBuilder.csproj
+++ b/src/Microsoft.OData.ModelBuilder/Microsoft.OData.ModelBuilder.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net8.0</TargetFrameworks>
     <RootNamespace>Microsoft.OData.ModelBuilder</RootNamespace>
     <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
+	<PackageReadmeFile>README.md</PackageReadmeFile>
     
     <!-- Let's generate our own assembly info -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
@@ -39,6 +40,10 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>VocabularyTermConfigurationExtensions.tt</DependentUpon>
     </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+	<None Include="README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description

This PR update `csproj` files by adding `README.md` as the package readme file. This is to ensure README.md is package when generating NuGet package.

https://devblogs.microsoft.com/nuget/add-a-readme-to-your-nuget-package/ 
https://learn.microsoft.com/en-us/nuget/reference/msbuild-targets#packagereadmefile

#### Summary:
1. `<PackageReadmeFile>README.md</PackageReadmeFile>`:
    - This line specifies that the README.md file should be included as the readme file in the NuGet package. When someone views your package on NuGet.org, this README file will be displayed.
2. `<None Include="README.md" Pack="true" PackagePath="\"/>`:
   - This line includes the README.md file in the package. The `Include` attribute specifies the file to include.
   - The `Pack="true"` attribute ensures that the file is included in the NuGet package.
   - The `PackagePath="\"` attribute specifies the path within the package where the file will be placed. In this case, it places the README.md file at the root of the package.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
