### PR TITLE
Migrate v1 pipeline to ESRP v5

### DIFF
--- a/build/azure-pipelines-nightly.yml
+++ b/build/azure-pipelines-nightly.yml
@@ -139,7 +139,7 @@ steps:
     ConnectedServiceName: $(ODataEsrpConnectionServiceName)
     AppRegistrationClientId: '$(ODataEsrpAppRegistrationClientId)'
     AppRegistrationTenantId: '$(ODataEsrpAppRegistrationTenantId)'
-    AuthAKVName: $(ODataEsrpAuthKVName)
+    AuthAKVName: $(ODataEsrpAuthAKVName)
     AuthCertName: $(ODataEsrpAuthCertName)
     AuthSignCertName: $(ODataEsrpAuthSignCertName)
     ServiceEndpointUrl: '$(ODataEsrpServiceEndpointUrl)'
@@ -230,7 +230,7 @@ steps:
     ConnectedServiceName: $(ODataEsrpConnectionServiceName)
     AppRegistrationClientId: '$(ODataEsrpAppRegistrationClientId)'
     AppRegistrationTenantId: '$(ODataEsrpAppRegistrationTenantId)'
-    AuthAKVName: $(ODataEsrpAuthKVName)
+    AuthAKVName: $(ODataEsrpAuthAKVName)
     AuthCertName: $(ODataEsrpAuthCertName)
     AuthSignCertName: $(ODataEsrpAuthSignCertName)
     ServiceEndpointUrl: '$(ODataEsrpServiceEndpointUrl)'

--- a/build/azure-pipelines-nightly.yml
+++ b/build/azure-pipelines-nightly.yml
@@ -18,12 +18,19 @@ pool:
   vmImage: 'windows-2022'
 
 variables:
-  BuildPlatform: 'Any CPU'
-  BuildConfiguration: 'Release'
-  snExe: 'C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\sn.exe'
-  snExe64: 'C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\x64\sn.exe'
-  ProductBinPath: '$(Build.SourcesDirectory)\src\Microsoft.OData.ModelBuilder\bin\$(BuildConfiguration)'
-  skipComponentGovernanceDetection: true
+- name: BuildPlatform
+  value: 'Any CPU'
+- name: BuildConfiguration
+  value: 'Release'
+- name: snExe
+  value: 'C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\sn.exe'
+- name: snExe64
+  value: 'C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\x64\sn.exe'
+- name: ProductBinPath
+  value: '$(Build.SourcesDirectory)\src\Microsoft.OData.ModelBuilder\bin\$(BuildConfiguration)'
+- name: skipComponentGovernanceDetection
+  value: true
+- group: OData-ESRP-CodeSigning
   
 steps:
 - task: NuGetToolInstaller@0
@@ -129,13 +136,13 @@ steps:
 - task: EsrpCodeSigning@5
   displayName: 'ESRP CodeSign - WebApi Product Signing'
   inputs:
-    ConnectedServiceName: 'ESRP CodeSigning - OData'
-    AppRegistrationClientId: 'ce6e119c-a8c2-4744-9699-cd5389102d0d'
-    AppRegistrationTenantId: '33e01921-4d64-4f8c-a055-5bdaffd5e33d'
-    AuthAKVName: ODataESRPKeyVault
-    AuthCertName: ODataCodeSignAuth-AutoRotate
-    AuthSignCertName: ODataCodeSigningCert2024
-    ServiceEndpointUrl: 'https://api.esrp.microsoft.com/api/v2'
+    ConnectedServiceName: $(ODataEsrpConnectionServiceName)
+    AppRegistrationClientId: '$(ODataEsrpAppRegistrationClientId)'
+    AppRegistrationTenantId: '$(ODataEsrpAppRegistrationTenantId)'
+    AuthAKVName: $(ODataEsrpAuthKVName)
+    AuthCertName: $(ODataEsrpAuthCertName)
+    AuthSignCertName: $(ODataEsrpAuthSignCertName)
+    ServiceEndpointUrl: '$(ODataEsrpServiceEndpointUrl)'
     FolderPath: '$(ProductBinPath)'
     Pattern: 'Microsoft.OData.ModelBuilder.dll'
     signConfigType: inlineSignParams
@@ -220,13 +227,13 @@ steps:
 - task: EsrpCodeSigning@5
   displayName: 'ESRP CodeSigning Nuget Packages'
   inputs:
-    ConnectedServiceName: 'ESRP CodeSigning - OData'
-    AppRegistrationClientId: 'ce6e119c-a8c2-4744-9699-cd5389102d0d'
-    AppRegistrationTenantId: '33e01921-4d64-4f8c-a055-5bdaffd5e33d'
-    AuthAKVName: ODataESRPKeyVault
-    AuthCertName: ODataCodeSignAuth-AutoRotate
-    AuthSignCertName: ODataCodeSigningCert2024
-    ServiceEndpointUrl: 'https://api.esrp.microsoft.com/api/v2'
+    ConnectedServiceName: $(ODataEsrpConnectionServiceName)
+    AppRegistrationClientId: '$(ODataEsrpAppRegistrationClientId)'
+    AppRegistrationTenantId: '$(ODataEsrpAppRegistrationTenantId)'
+    AuthAKVName: $(ODataEsrpAuthKVName)
+    AuthCertName: $(ODataEsrpAuthCertName)
+    AuthSignCertName: $(ODataEsrpAuthSignCertName)
+    ServiceEndpointUrl: '$(ODataEsrpServiceEndpointUrl)'
     FolderPath: '$(Build.ArtifactStagingDirectory)\Nuget'
     Pattern: '*.nupkg'
     signConfigType: inlineSignParams

--- a/build/azure-pipelines-nightly.yml
+++ b/build/azure-pipelines-nightly.yml
@@ -6,7 +6,7 @@ trigger: none
 # No Pull request (PR) triggers for nightly
 pr: none
 
-# Nightly using schedules
+# Nightly using schedule
 schedules:
 - cron: "0 0 * * Mon,Tue,Wed,Thu,Fri"
   displayName: midnightly build
@@ -14,259 +14,252 @@ schedules:
     include:
     - main
 
-pool:
-  vmImage: 'windows-2022'
+resources:
+  repositories:
+  - repository: self
+    type: git
+    ref: refs/heads/main
+  - repository: 1ESPipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
 
 variables:
-- name: BuildPlatform
+- name: buildPlatform
   value: 'Any CPU'
-- name: BuildConfiguration
+- name: buildConfiguration
   value: 'Release'
 - name: snExe
   value: 'C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\sn.exe'
 - name: snExe64
   value: 'C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\x64\sn.exe'
-- name: ProductBinPath
-  value: '$(Build.SourcesDirectory)\src\Microsoft.OData.ModelBuilder\bin\$(BuildConfiguration)'
+- name: productBinPath
+  value: '$(Build.SourcesDirectory)\src\Microsoft.OData.ModelBuilder\bin\$(buildConfiguration)'
 - name: skipComponentGovernanceDetection
   value: true
 - group: OData-ESRP-CodeSigning
-  
-steps:
-- task: NuGetToolInstaller@0
-  inputs:
-    versionSpec: '>=5.2.0'
 
-# Add this Command to Include the .NET 6 SDK
-- task: UseDotNet@2
-  displayName: Use .NET 6.0
-  inputs:
-    packageType: 'sdk'
-    version: '6.0.x'
-    
-# because the assemblies are delay-signed, we need to disable
-# strong name validation so that the tests may run,
-# otherwise our assemblies will fail to load
-- task: Powershell@2
-  displayName: 'Skip strong name validation'
-  inputs:
-    targetType: 'inline'
-    script: |
-      & "$(snExe)" /Vr $(ProductBinPath)\$(mainDll)
-      & "$(snExe64)" /Vr $(ProductBinPath)\$(mainDll)
-      & "$(snExe)" /Vr $(testBinPath)\$(testDll)
-      & "$(snExe64)" /Vr $(testBinPath)\$(testDll)
-  enabled: false
-  
-# Build the Product project
-- task: DotNetCoreCLI@2
-  displayName: 'build Microsoft.OData.ModelBuilder.csproj '
-  inputs:
-    projects: '$(Build.SourcesDirectory)\src\Microsoft.OData.ModelBuilder\Microsoft.OData.ModelBuilder.csproj'
-    arguments: '--configuration $(BuildConfiguration) --no-incremental'
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    pool:
+      name: MSSecurity-1ES-Build-Agents-Pool
+      image: MSSecurity-1ES-Windows-2019
+      os: windows
+    customBuildTags:
+    - ES365AIMigrationTooling
+    stages:
+    - stage: build
+      jobs:
+      - job: Release
+        templateContext:
+          outputs:
+          - output: pipelineArtifact
+            displayName: 'Publish Artifact - Nuget Packages'
+            targetPath: '$(Build.ArtifactStagingDirectory)\Nuget'
+            artifactName: Nuget
+          - output: nuget
+            displayName: 'NuGet push - Nightly packages to MyGet'
+            packageParentPath: '$(Build.ArtifactStagingDirectory)'
+            packagesToPush: '$(Build.ArtifactStagingDirectory)\Nuget\*Nightly*.nupkg'
+            nuGetFeedType: external
+            publishFeedCredentials: 'MyGet.org - ODL Feed'
+        steps:
+        - task: NuGetToolInstaller@0
+          inputs:
+            versionSpec: '>=5.2.0'
 
-# Build the Unit test project
-- task: DotNetCoreCLI@2
-  displayName: 'build Microsoft.OData.ModelBuilder Unit test project'
-  inputs:
-    projects: '$(Build.SourcesDirectory)\test\Microsoft.OData.ModelBuilder.Tests\Microsoft.OData.ModelBuilder.Tests.csproj'
-    arguments: '--configuration $(BuildConfiguration) --no-incremental'
+        - task: UseDotNet@2
+          displayName: Use .NET 8.0
+          inputs:
+            packageType: 'sdk'
+            version: '8.0.x'
 
-- task: UseDotNet@2
-  displayName: Use .NET 3.x
-  inputs:
-    packageType: 'sdk'
-    version: '3.x'
+        - task: Powershell@2
+          displayName: 'Skip Strong Name Validation'
+          inputs:
+            targetType: 'inline'
+            script: |
+              & "$(snExe)" /Vr $(productBinPath)\$(mainDll)
+              & "$(snExe64)" /Vr $(productBinPath)\$(mainDll)
+              & "$(snExe)" /Vr $(testBinPath)\$(testDll)
+              & "$(snExe64)" /Vr $(testBinPath)\$(testDll)
+          enabled: false
 
-# Run the Unit test
-- task: DotNetCoreCLI@2
-  displayName: 'Unit Tests (Microsoft.OData.ModelBuilder.Tests.csproj) '
-  inputs:
-    command: test
-    projects: '$(Build.SourcesDirectory)\test\Microsoft.OData.ModelBuilder.Tests\Microsoft.OData.ModelBuilder.Tests.csproj'
-    arguments: '--configuration $(BuildConfiguration) --no-build'
+        - task: DotNetCoreCLI@2
+          displayName: 'Build Microsoft.OData.ModelBuilder.csproj '
+          inputs:
+            projects: '$(Build.SourcesDirectory)\src\Microsoft.OData.ModelBuilder\Microsoft.OData.ModelBuilder.csproj'
+            arguments: '--configuration $(buildConfiguration) --no-incremental'
 
-# CredScan
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@2
-  displayName: 'Run CredScan - Src'
-  inputs:
-    toolMajorVersion: 'V2'
-    scanFolder: '$(Build.SourcesDirectory)\src'
-    debugMode: false
+        - task: DotNetCoreCLI@2
+          displayName: 'Build Microsoft.OData.ModelBuilder Unit test project'
+          inputs:
+            projects: '$(Build.SourcesDirectory)\test\Microsoft.OData.ModelBuilder.Tests\Microsoft.OData.ModelBuilder.Tests.csproj'
+            arguments: '--configuration $(buildConfiguration) --no-incremental'
 
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@2
-  displayName: 'Run CredScan - Test'
-  inputs:
-    toolMajorVersion: 'V2'
-    scanFolder: '$(Build.SourcesDirectory)\test'
-    debugMode: false
-  
-# Microsoft.CodeAnalysis.FxCopAnalyzers is added into the project.
-# Typically, .NET Standard (.NET Core) project doesn't need the FxCop.
+        - task: UseDotNet@2
+          displayName: Use .NET 3.x
+          inputs:
+            packageType: 'sdk'
+            version: '3.x'
 
-# Needn't the AntiMalware@3 task?
-- task: AntiMalware@3
-  displayName: 'Run MpCmdRun.exe - ProductBinPath'
-  inputs:
-    FileDirPath: '$(ProductBinPath)'
-  enabled: false
+        - task: DotNetCoreCLI@2
+          displayName: 'Unit Tests (Microsoft.OData.ModelBuilder.Tests.csproj) '
+          inputs:
+            command: test
+            projects: '$(Build.SourcesDirectory)\test\Microsoft.OData.ModelBuilder.Tests\Microsoft.OData.ModelBuilder.Tests.csproj'
+            arguments: '--configuration $(buildConfiguration) --no-build'
 
-- task: BinSkim@3
-  displayName: 'Run BinSkim - Product Binaries'
-  inputs:
-    InputType: Basic
-    AnalyzeTarget: '$(ProductBinPath)\**\Microsoft.OData.ModelBuilder.dll'
-    AnalyzeSymPath: '$(ProductBinPath)'
-    AnalyzeVerbose: true
-    AnalyzeHashes: true
-    AnalyzeEnvironment: true
+        - task: BinSkim@3
+          displayName: 'Run BinSkim - Product Binaries'
+          inputs:
+            InputType: Basic
+            AnalyzeTarget: '$(productBinPath)\**\Microsoft.OData.ModelBuilder.dll'
+            AnalyzeSymPath: '$(productBinPath)'
+            AnalyzeVerbose: true
+            AnalyzeHashes: true
+            AnalyzeEnvironment: true
 
-- task: PublishSecurityAnalysisLogs@2
-  displayName: 'Publish Security Analysis Logs'
-  inputs:
-    ArtifactName: SecurityLogs
+        - task: PublishSecurityAnalysisLogs@3
+          displayName: 'Publish Security Analysis Logs'
+          inputs:
+            ArtifactName: SecurityLogs
 
-- task: PostAnalysis@1
-  displayName: 'Post Analysis'
-  inputs:
-    BinSkim: true
-    CredScan: true
-    PoliCheck: true
+        - task: PostAnalysis@2
+          displayName: 'Post Analysis'
+          inputs:
+            BinSkim: true
+            CredScan: true
+            PoliCheck: true
 
-- task: EsrpCodeSigning@5
-  displayName: 'ESRP CodeSign - WebApi Product Signing'
-  inputs:
-    ConnectedServiceName: $(ODataEsrpConnectionServiceName)
-    AppRegistrationClientId: '$(ODataEsrpAppRegistrationClientId)'
-    AppRegistrationTenantId: '$(ODataEsrpAppRegistrationTenantId)'
-    AuthAKVName: $(ODataEsrpAuthAKVName)
-    AuthCertName: $(ODataEsrpAuthCertName)
-    AuthSignCertName: $(ODataEsrpAuthSignCertName)
-    ServiceEndpointUrl: '$(ODataEsrpServiceEndpointUrl)'
-    FolderPath: '$(ProductBinPath)'
-    Pattern: 'Microsoft.OData.ModelBuilder.dll'
-    signConfigType: inlineSignParams
-    inlineOperation: |
-     [
-       {
-         "keyCode": "MSSharedLibSnKey",
-         "operationSetCode": "StrongNameSign",
-         "parameters": null,
-         "toolName": "sn.exe",
-         "toolVersion": "V4.6.1586.0"
-       },
-       {
-         "keyCode": "MSSharedLibSnKey",
-         "operationSetCode": "StrongNameVerify",
-         "parameters": null,
-         "toolName": "sn.exe",
-         "toolVersion": "V4.6.1586.0"
-       },
-       {
-         "keyCode": "CP-230012",
-         "operationSetCode": "SigntoolSign",
-         "parameters": [
-         {
-           "parameterName": "OpusName",
-           "parameterValue": "Microsoft"
-         },
-         {
-           "parameterName": "OpusInfo",
-           "parameterValue": "http://www.microsoft.com"
-         },
-         {
-           "parameterName": "PageHash",
-           "parameterValue": "/NPH"
-         },
-         {
-           "parameterName": "FileDigest",
-           "parameterValue": "/fd sha256"
-         },
-         {
-           "parameterName": "TimeStamp",
-           "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-         }
-         ],
-         "toolName": "signtool.exe",
-         "toolVersion": "6.2.9304.0"
-       },
-       {
-         "keyCode": "CP-230012",
-         "operationSetCode": "SigntoolVerify",
-         "parameters": [
-         {
-           "parameterName": "VerifyAll",
-           "parameterValue": "/all"
-         }
-         ],
-         "toolName": "signtool.exe",
-         "toolVersion": "6.2.9304.0"
-       }
-     ]
-    VerboseLogin: true
-    
-- task: MSBuild@1
-  displayName: 'Get Nuget Package Metadata'
-  inputs:
-    solution: '$(Build.SourcesDirectory)\build\GetNugetPackageMetadata.proj'
-    platform: '$(BuildPlatform)'
-    configuration: '$(BuildConfiguration)'
-    
-- task: NuGetCommand@2
-  displayName: 'NuGet - pack Microsoft.OData.ModelBuilder.Nightly.nuspec '
-  inputs:
-    command: custom
-    arguments: 'pack $(Build.SourcesDirectory)\src\Microsoft.OData.ModelBuilder\Microsoft.OData.ModelBuilder.Nightly.nuspec -NonInteractive -OutputDirectory $(Build.ArtifactStagingDirectory)\Nuget -Properties Configuration=$(BuildConfiguration);ProductRoot=$(ProductBinPath);SourcesRoot=$(Build.SourcesDirectory);VersionFullSemantic=$(VersionFullSemantic);NightlyBuildVersion=$(VersionNugetNightlyBuild);VersionNuGetSemantic=$(VersionNuGetSemantic);SystemComponentPackageDependency="$(SystemComponentPackageDependency)";ODataLibPackageDependency="$(ODataLibPackageDependency)" -Verbosity Detailed -Symbols -Symbols -SymbolPackageFormat snupkg'
-    
-- task: NuGetCommand@2
-  displayName: 'NuGet - pack Microsoft.OData.ModelBuilder.Release.nuspec '
-  inputs:
-    command: custom
-    arguments: 'pack $(Build.SourcesDirectory)\src\Microsoft.OData.ModelBuilder\Microsoft.OData.ModelBuilder.Release.nuspec -NonInteractive -OutputDirectory $(Build.ArtifactStagingDirectory)\Nuget -Properties Configuration=$(BuildConfiguration);ProductRoot=$(ProductBinPath);SourcesRoot=$(Build.SourcesDirectory);VersionFullSemantic=$(VersionFullSemantic);VersionNuGetSemantic=$(VersionNuGetSemantic);SystemComponentPackageDependency="$(SystemComponentPackageDependency)";ODataLibPackageDependency="$(ODataLibPackageDependency)" -Verbosity Detailed -Symbols -Symbols -SymbolPackageFormat snupkg'
-   
-- task: EsrpCodeSigning@5
-  displayName: 'ESRP CodeSigning Nuget Packages'
-  inputs:
-    ConnectedServiceName: $(ODataEsrpConnectionServiceName)
-    AppRegistrationClientId: '$(ODataEsrpAppRegistrationClientId)'
-    AppRegistrationTenantId: '$(ODataEsrpAppRegistrationTenantId)'
-    AuthAKVName: $(ODataEsrpAuthAKVName)
-    AuthCertName: $(ODataEsrpAuthCertName)
-    AuthSignCertName: $(ODataEsrpAuthSignCertName)
-    ServiceEndpointUrl: '$(ODataEsrpServiceEndpointUrl)'
-    FolderPath: '$(Build.ArtifactStagingDirectory)\Nuget'
-    Pattern: '*.nupkg'
-    signConfigType: inlineSignParams
-    inlineOperation: |
-     [
-         {
-             "keyCode": "CP-401405",
-             "operationSetCode": "NuGetSign",
-             "parameters": [ ],
-             "toolName": "sign",
-             "toolVersion": "1.0"
-         },
-         {
-             "keyCode": "CP-401405",
-             "operationSetCode": "NuGetVerify",
-             "parameters": [ ],
-             "toolName": "sign",
-             "toolVersion": "1.0"
-         }
-     ]
-    VerboseLogin: true
+        # ESRP code signing task depends on .NET Core 2.x SDK
+        - task: UseDotNet@2
+          displayName: Use .NET Core 2.x
+          inputs:
+            version: '2.1.x'
 
-- task: PublishBuildArtifacts@1
-  displayName: 'Publish Artifact - Nuget Packages'
-  inputs:
-    PathtoPublish: '$(Build.ArtifactStagingDirectory)\Nuget'
-    ArtifactName: Nuget
+        # CodeSign
+        - task: EsrpCodeSigning@5
+          displayName: 'ESRP CodeSign - OData'
+          inputs:
+            ConnectedServiceName: $(ODataEsrpConnectionServiceName)
+            AppRegistrationClientId: '$(ODataEsrpAppRegistrationClientId)'
+            AppRegistrationTenantId: '$(ODataEsrpAppRegistrationTenantId)'
+            AuthAKVName: $(ODataEsrpAuthAKVName)
+            AuthCertName: $(ODataEsrpAuthCertName)
+            AuthSignCertName: $(ODataEsrpAuthSignCertName)
+            ServiceEndpointUrl: '$(ODataEsrpServiceEndpointUrl)'
+            FolderPath: '$(productBinPath)'
+            Pattern: 'Microsoft.OData.ModelBuilder.dll'
+            signConfigType: inlineSignParams
+            inlineOperation: |
+             [
+               {
+                 "keyCode": "MSSharedLibSnKey",
+                 "operationSetCode": "StrongNameSign",
+                 "parameters": null,
+                 "toolName": "sn.exe",
+                 "toolVersion": "V4.6.1586.0"
+               },
+               {
+                 "keyCode": "MSSharedLibSnKey",
+                 "operationSetCode": "StrongNameVerify",
+                 "parameters": null,
+                 "toolName": "sn.exe",
+                 "toolVersion": "V4.6.1586.0"
+               },
+               {
+                 "keyCode": "CP-230012",
+                 "operationSetCode": "SigntoolSign",
+                 "parameters": [
+                 {
+                   "parameterName": "OpusName",
+                   "parameterValue": "TestSign"
+                 },
+                 {
+                   "parameterName": "OpusInfo",
+                   "parameterValue": "http://test"
+                 },
+                 {
+                   "parameterName": "PageHash",
+                   "parameterValue": "/NPH"
+                 },
+                 {
+                   "parameterName": "FileDigest",
+                   "parameterValue": "/fd sha256"
+                 },
+                 {
+                   "parameterName": "TimeStamp",
+                   "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+                 }
+                 ],
+                 "toolName": "signtool.exe",
+                 "toolVersion": "6.2.9304.0"
+               },
+               {
+                 "keyCode": "CP-230012",
+                 "operationSetCode": "SigntoolVerify",
+                 "parameters": [
+                 {
+                   "parameterName": "VerifyAll",
+                   "parameterValue": "/all"
+                 }
+                 ],
+                 "toolName": "signtool.exe",
+                 "toolVersion": "6.2.9304.0"
+               }
+             ]
+            SessionTimeout: 20
+            VerboseLogin: true
 
-# Push the odata model builder nightly to MyGet
-- task: NuGetCommand@2
-  displayName: 'NuGet push - Nightly packages to MyGet'
-  inputs:
-    command: push
-    packagesToPush: '$(Build.ArtifactStagingDirectory)\Nuget\*Nightly*.nupkg'
-    nuGetFeedType: external
-    publishFeedCredentials: 'MyGet.org - OData.net new nightly feed'
+        - task: MSBuild@1
+          displayName: 'Get Nuget Package Metadata'
+          inputs:
+            solution: '$(Build.SourcesDirectory)\build\GetNugetPackageMetadata.proj'
+            platform: '$(buildPlatform)'
+            configuration: '$(buildConfiguration)'
+
+        - task: NuGetCommand@2
+          displayName: 'NuGet - pack Microsoft.OData.ModelBuilder.Nightly.nuspec'
+          inputs:
+            command: custom
+            arguments: 'pack $(Build.SourcesDirectory)\src\Microsoft.OData.ModelBuilder\Microsoft.OData.ModelBuilder.Nightly.nuspec -NonInteractive -OutputDirectory $(Build.ArtifactStagingDirectory)\Nuget -Properties Configuration=$(buildConfiguration);ProductRoot=$(productBinPath);SourcesRoot=$(Build.SourcesDirectory);VersionFullSemantic=$(VersionFullSemantic);NightlyBuildVersion=$(VersionNugetNightlyBuild);VersionNuGetSemantic=$(VersionNuGetSemantic);SystemComponentPackageDependency="$(SystemComponentPackageDependency)";ODataLibPackageDependency="$(ODataLibPackageDependency)" -Verbosity Detailed -Symbols -Symbols -SymbolPackageFormat snupkg'
+
+        - task: NuGetCommand@2
+          displayName: 'NuGet - pack Microsoft.OData.ModelBuilder.Release.nuspec'
+          inputs:
+            command: custom
+            arguments: 'pack $(Build.SourcesDirectory)\src\Microsoft.OData.ModelBuilder\Microsoft.OData.ModelBuilder.Release.nuspec -NonInteractive -OutputDirectory $(Build.ArtifactStagingDirectory)\Nuget -Properties Configuration=$(buildConfiguration);ProductRoot=$(productBinPath);SourcesRoot=$(Build.SourcesDirectory);VersionFullSemantic=$(VersionFullSemantic);VersionNuGetSemantic=$(VersionNuGetSemantic);SystemComponentPackageDependency="$(SystemComponentPackageDependency)";ODataLibPackageDependency="$(ODataLibPackageDependency)" -Verbosity Detailed -Symbols -Symbols -SymbolPackageFormat snupkg'
+
+        - task: EsrpCodeSigning@5
+          displayName: 'ESRP CodeSigning Nuget Packages'
+          inputs:
+            ConnectedServiceName: $(ODataEsrpConnectionServiceName)
+            AppRegistrationClientId: '$(ODataEsrpAppRegistrationClientId)'
+            AppRegistrationTenantId: '$(ODataEsrpAppRegistrationTenantId)'
+            AuthAKVName: $(ODataEsrpAuthAKVName)
+            AuthCertName: $(ODataEsrpAuthCertName)
+            AuthSignCertName: $(ODataEsrpAuthSignCertName)
+            ServiceEndpointUrl: '$(ODataEsrpServiceEndpointUrl)'
+            FolderPath: '$(Build.ArtifactStagingDirectory)\Nuget'
+            Pattern: '*.nupkg'
+            signConfigType: inlineSignParams
+            inlineOperation: |
+              [
+                  {
+                      "keyCode": "CP-401405",
+                      "operationSetCode": "NuGetSign",
+                      "parameters": [ ],
+                      "toolName": "sign",
+                      "toolVersion": "1.0"
+                  },
+                  {
+                      "keyCode": "CP-401405",
+                      "operationSetCode": "NuGetVerify",
+                      "parameters": [ ],
+                      "toolName": "sign",
+                      "toolVersion": "1.0"
+                  }
+              ]
+            VerboseLogin: true

--- a/build/azure-pipelines-nightly.yml
+++ b/build/azure-pipelines-nightly.yml
@@ -35,8 +35,6 @@ variables:
   value: 'C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\x64\sn.exe'
 - name: productBinPath
   value: '$(Build.SourcesDirectory)\src\Microsoft.OData.ModelBuilder\bin\$(buildConfiguration)'
-- name: skipComponentGovernanceDetection
-  value: true
 - group: OData-ESRP-CodeSigning
 
 extends:
@@ -70,10 +68,10 @@ extends:
             versionSpec: '>=5.2.0'
 
         - task: UseDotNet@2
-          displayName: Use .NET 8.0
+          displayName: Use .NET 6.0
           inputs:
             packageType: 'sdk'
-            version: '8.0.x'
+            version: '6.0.x'
 
         - task: Powershell@2
           displayName: 'Skip Strong Name Validation'

--- a/build/azure-pipelines-nightly.yml
+++ b/build/azure-pipelines-nightly.yml
@@ -126,10 +126,16 @@ steps:
     CredScan: true
     PoliCheck: true
 
-- task: EsrpCodeSigning@1
+- task: EsrpCodeSigning@5
   displayName: 'ESRP CodeSign - WebApi Product Signing'
   inputs:
     ConnectedServiceName: 'ESRP CodeSigning - OData'
+    AppRegistrationClientId: 'ce6e119c-a8c2-4744-9699-cd5389102d0d'
+    AppRegistrationTenantId: '33e01921-4d64-4f8c-a055-5bdaffd5e33d'
+    AuthAKVName: ODataESRPKeyVault
+    AuthCertName: ODataCodeSignAuth-AutoRotate
+    AuthSignCertName: ODataCodeSigningCert2024
+    ServiceEndpointUrl: 'https://api.esrp.microsoft.com/api/v2'
     FolderPath: '$(ProductBinPath)'
     Pattern: 'Microsoft.OData.ModelBuilder.dll'
     signConfigType: inlineSignParams
@@ -211,10 +217,16 @@ steps:
     command: custom
     arguments: 'pack $(Build.SourcesDirectory)\src\Microsoft.OData.ModelBuilder\Microsoft.OData.ModelBuilder.Release.nuspec -NonInteractive -OutputDirectory $(Build.ArtifactStagingDirectory)\Nuget -Properties Configuration=$(BuildConfiguration);ProductRoot=$(ProductBinPath);SourcesRoot=$(Build.SourcesDirectory);VersionFullSemantic=$(VersionFullSemantic);VersionNuGetSemantic=$(VersionNuGetSemantic);SystemComponentPackageDependency="$(SystemComponentPackageDependency)";ODataLibPackageDependency="$(ODataLibPackageDependency)" -Verbosity Detailed -Symbols -Symbols -SymbolPackageFormat snupkg'
    
-- task: EsrpCodeSigning@1
+- task: EsrpCodeSigning@5
   displayName: 'ESRP CodeSigning Nuget Packages'
   inputs:
     ConnectedServiceName: 'ESRP CodeSigning - OData'
+    AppRegistrationClientId: 'ce6e119c-a8c2-4744-9699-cd5389102d0d'
+    AppRegistrationTenantId: '33e01921-4d64-4f8c-a055-5bdaffd5e33d'
+    AuthAKVName: ODataESRPKeyVault
+    AuthCertName: ODataCodeSignAuth-AutoRotate
+    AuthSignCertName: ODataCodeSigningCert2024
+    ServiceEndpointUrl: 'https://api.esrp.microsoft.com/api/v2'
     FolderPath: '$(Build.ArtifactStagingDirectory)\Nuget'
     Pattern: '*.nupkg'
     signConfigType: inlineSignParams

--- a/build/azure-pipelines-rolling.yml
+++ b/build/azure-pipelines-rolling.yml
@@ -31,7 +31,6 @@ variables:
   productBinPath: '$(Build.SourcesDirectory)\src\Microsoft.OData.ModelBuilder\bin\$(buildConfiguration)'
   mainDll: 'Microsoft.OData.ModelBuilder.dll'
   testDll: 'Microsoft.OData.ModelBuilder.Tests.dll'
-  skipComponentGovernanceDetection: true
 
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
@@ -66,10 +65,10 @@ extends:
             checkLatest: true
 
         - task: UseDotNet@2
-          displayName: Use .NET 8.0
+          displayName: Use .NET 6.0
           inputs:
             packageType: 'sdk'
-            version: '8.0.x'
+            version: '6.0.x'
 
         - task: DotNetCoreCLI@2
           displayName: 'Build Microsoft.OData.ModelBuilder.csproj '

--- a/build/azure-pipelines-rolling.yml
+++ b/build/azure-pipelines-rolling.yml
@@ -1,5 +1,4 @@
 name: $(TeamProject)_$(BuildDefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)
-
 trigger:
 # Set batch to true, it means to let system waits to run until current run is completed,
 # Then starts another run with all changes.
@@ -7,137 +6,125 @@ trigger:
   branches:
     include:
     - main
+    - release-1.x
 
 # Pull request (PR) triggers
 pr:
 - main
+- release-1.x
 
-pool:
-  vmImage: 'windows-2022'
-  
+resources:
+  repositories:
+  - repository: self
+    type: git
+    ref: refs/heads/main
+  - repository: 1ESPipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+
 variables:
-  BuildPlatform: 'Any CPU'
-  BuildConfiguration: 'Release'
+  buildPlatform: 'Any CPU'
+  buildConfiguration: 'Release'
   snExe: 'C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\sn.exe'
   snExe64: 'C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\x64\sn.exe'
-  ProductBinPath: '$(Build.SourcesDirectory)\src\Microsoft.OData.ModelBuilder\bin\$(BuildConfiguration)'
+  productBinPath: '$(Build.SourcesDirectory)\src\Microsoft.OData.ModelBuilder\bin\$(buildConfiguration)'
   mainDll: 'Microsoft.OData.ModelBuilder.dll'
   testDll: 'Microsoft.OData.ModelBuilder.Tests.dll'
   skipComponentGovernanceDetection: true
 
-steps:
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    pool:
+      name: MSSecurity-1ES-Build-Agents-Pool
+      image: MSSecurity-1ES-Windows-2019
+      os: windows
+    customBuildTags:
+    - ES365AIMigrationTooling
+    stages:
+    - stage: build
+      jobs:
+      - job: Release
+        steps:
+        - task: PoliCheck@2
+          displayName: 'Run PoliCheck ".\src"'
+          inputs:
+            inputType: CmdLine
+            cmdLineArgs: '/F:$(Build.SourcesDirectory)/src /T:9 /Sev:"1|2" /PE:2 /O:poli_result_src.xml'
 
-- task: PoliCheck@1
-  displayName: 'Run PoliCheck ".\src"'
-  inputs:
-    inputType: CmdLine
-    cmdLineArgs: '/F:$(Build.SourcesDirectory)/src /T:9 /Sev:"1|2" /PE:2 /O:poli_result_src.xml'
+        - task: PoliCheck@2
+          displayName: 'Run PoliCheck ".\test"'
+          inputs:
+            inputType: CmdLine
+            cmdLineArgs: '/F:$(Build.SourcesDirectory)/test /T:9 /Sev:"1|2" /PE:2 /O:poli_result_test.xml'
 
-- task: PoliCheck@1
-  displayName: 'Run PoliCheck ".\test"'
-  inputs:
-    inputType: CmdLine
-    cmdLineArgs: '/F:$(Build.SourcesDirectory)/test /T:9 /Sev:"1|2" /PE:2 /O:poli_result_test.xml'
+        - task: NuGetToolInstaller@0
+          displayName: 'Use NuGet >=5.2.0'
+          inputs:
+            versionSpec: '>=5.2.0'
+            checkLatest: true
 
-# Install the nuget tooler.
-- task: NuGetToolInstaller@0
-  displayName: 'Use NuGet >=5.2.0'
-  inputs:
-    versionSpec: '>=5.2.0'
-    checkLatest: true
-    
-# Add this Command to Include the .NET 6 SDK
-- task: UseDotNet@2
-  displayName: Use .NET 6.0
-  inputs:
-    packageType: 'sdk'
-    version: '6.0.x'
+        - task: UseDotNet@2
+          displayName: Use .NET 8.0
+          inputs:
+            packageType: 'sdk'
+            version: '8.0.x'
 
-# Build the Product project
-- task: DotNetCoreCLI@2
-  displayName: 'build Microsoft.OData.ModelBuilder.csproj '
-  inputs:
-    projects: '$(Build.SourcesDirectory)\src\Microsoft.OData.ModelBuilder\Microsoft.OData.ModelBuilder.csproj'
-    arguments: '--configuration $(BuildConfiguration) --no-incremental'
+        - task: DotNetCoreCLI@2
+          displayName: 'Build Microsoft.OData.ModelBuilder.csproj '
+          inputs:
+            projects: '$(Build.SourcesDirectory)\src\Microsoft.OData.ModelBuilder\Microsoft.OData.ModelBuilder.csproj'
+            arguments: '--configuration $(buildConfiguration) --no-incremental'
 
-# Build the Unit test project
-- task: DotNetCoreCLI@2
-  displayName: 'build Microsoft.OData.ModelBuilder Unit test project'
-  inputs:
-    projects: '$(Build.SourcesDirectory)\test\Microsoft.OData.ModelBuilder.Tests\Microsoft.OData.ModelBuilder.Tests.csproj'
-    arguments: '--configuration $(BuildConfiguration) --no-incremental'
+        - task: DotNetCoreCLI@2
+          displayName: 'Build Microsoft.OData.ModelBuilder Unit test project'
+          inputs:
+            projects: '$(Build.SourcesDirectory)\test\Microsoft.OData.ModelBuilder.Tests\Microsoft.OData.ModelBuilder.Tests.csproj'
+            arguments: '--configuration $(buildConfiguration) --no-incremental'
 
-- task: UseDotNet@2
-  displayName: Use .NET 3.x
-  inputs:
-    packageType: 'sdk'
-    version: '3.x'
+        - task: UseDotNet@2
+          displayName: Use .NET 3.x
+          inputs:
+            packageType: 'sdk'
+            version: '3.x'
 
-# Run the Unit test
-- task: DotNetCoreCLI@2
-  displayName: 'Unit Tests (Microsoft.OData.ModelBuilder.Tests.csproj) '
-  inputs:
-    command: test
-    projects: '$(Build.SourcesDirectory)\test\Microsoft.OData.ModelBuilder.Tests\Microsoft.OData.ModelBuilder.Tests.csproj'
-    arguments: '--configuration $(BuildConfiguration) --no-build'
+        - task: DotNetCoreCLI@2
+          displayName: 'Unit Tests (Microsoft.OData.ModelBuilder.Tests.csproj) '
+          inputs:
+            command: test
+            projects: '$(Build.SourcesDirectory)\test\Microsoft.OData.ModelBuilder.Tests\Microsoft.OData.ModelBuilder.Tests.csproj'
+            arguments: '--configuration $(buildConfiguration) --no-build'
 
-# because the assemblies are delay-signed, we need to disable
-# strong name validation so that the tests may run,
-# otherwise our assemblies will fail to load
-- task: Powershell@2
-  displayName: 'Skip strong name validation'
-  inputs:
-    targetType: 'inline'
-    script: |
-      & "$(snExe)" /Vr $(ProductBinPath)\$(mainDll)
-      & "$(snExe64)" /Vr $(ProductBinPath)\$(mainDll)
-      & "$(snExe)" /Vr $(testBinPath)\$(testDll)
-      & "$(snExe64)" /Vr $(testBinPath)\$(testDll)
-  enabled: false
-  
-# CredScan
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@2
-  displayName: 'Run CredScan - Src'
-  inputs:
-    toolMajorVersion: 'V2'
-    scanFolder: '$(Build.SourcesDirectory)\src'
-    debugMode: false
+        - task: Powershell@2
+          displayName: 'Skip Strong Name Validation'
+          inputs:
+            targetType: 'inline'
+            script: |
+              & "$(snExe)" /Vr $(productBinPath)\$(mainDll)
+              & "$(snExe64)" /Vr $(productBinPath)\$(mainDll)
+              & "$(snExe)" /Vr $(testBinPath)\$(testDll)
+              & "$(snExe64)" /Vr $(testBinPath)\$(testDll)
+          enabled: false
 
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@2
-  displayName: 'Run CredScan - Test'
-  inputs:
-    toolMajorVersion: 'V2'
-    scanFolder: '$(Build.SourcesDirectory)\test'
-    debugMode: false
-  
-# Microsoft.CodeAnalysis.FxCopAnalyzers is added into the project.
-# Typically, .NET Standard (.NET Core) project doesn't need the FxCop.
+        - task: BinSkim@3
+          displayName: 'Run BinSkim - Product Binaries'
+          inputs:
+            InputType: Basic
+            AnalyzeTarget: '$(productBinPath)\**\Microsoft.OData.ModelBuilder.dll'
+            AnalyzeSymPath: '$(productBinPath)'
+            AnalyzeVerbose: true
+            AnalyzeHashes: true
+            AnalyzeEnvironment: true
 
-# Needn't the AntiMalware@3 task?
-- task: AntiMalware@3
-  displayName: 'Run MpCmdRun.exe - ProductBinPath'
-  inputs:
-    FileDirPath: '$(ProductBinPath)'
-  enabled: false
+        - task: PublishSecurityAnalysisLogs@3
+          displayName: 'Publish Security Analysis Logs'
+          inputs:
+            ArtifactName: SecurityLogs
 
-- task: BinSkim@3
-  displayName: 'Run BinSkim - Product Binaries'
-  inputs:
-    InputType: Basic
-    AnalyzeTarget: '$(ProductBinPath)\**\Microsoft.OData.ModelBuilder.dll'
-    AnalyzeSymPath: '$(ProductBinPath)'
-    AnalyzeVerbose: true
-    AnalyzeHashes: true
-    AnalyzeEnvironment: true
-
-- task: PublishSecurityAnalysisLogs@2
-  displayName: 'Publish Security Analysis Logs'
-  inputs:
-    ArtifactName: SecurityLogs
-
-- task: PostAnalysis@1
-  displayName: 'Post Analysis'
-  inputs:
-    BinSkim: true
-    CredScan: true
-    PoliCheck: true
+        - task: PostAnalysis@2
+          displayName: 'Post Analysis'
+          inputs:
+            BinSkim: true
+            CredScan: true
+            PoliCheck: true


### PR DESCRIPTION
Migrate ModelBuilder 1.x pipeline to ESRP v5

Apparently the v1 pipeline was not yet migrated to 1ES, so I migrated it to 1ES as well.