### PR TITLE
Add no-op for adding the same dynamic dictionary property more than once

### DIFF
--- a/src/Microsoft.OData.ModelBuilder/Types/StructuralTypeConfiguration.cs
+++ b/src/Microsoft.OData.ModelBuilder/Types/StructuralTypeConfiguration.cs
@@ -513,6 +513,12 @@ namespace Microsoft.OData.ModelBuilder
                 RemovedProperties.Remove(propertyInfo);
             }
 
+            // No-op if configuring the same property more than once
+            if (DynamicPropertyDictionary == propertyInfo)
+            {
+                return;
+            }
+
             if (DynamicPropertyDictionary != null)
             {
                 throw Error.Argument("propertyInfo", SRResources.MoreThanOneDynamicPropertyContainerFound, ClrType.Name);

--- a/test/Microsoft.OData.ModelBuilder.Tests/Types/StructuralTypeConfigurationTest.cs
+++ b/test/Microsoft.OData.ModelBuilder.Tests/Types/StructuralTypeConfigurationTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using Microsoft.OData.ModelBuilder.Tests.Commons;
 using Microsoft.OData.ModelBuilder.Tests.TestModels;
 using Moq;
@@ -53,6 +54,39 @@ namespace Microsoft.OData.ModelBuilder.Tests.Types
             ExceptionAssert.ThrowsArgument(() => configuration.AddDynamicPropertyDictionary(property),
                 "propertyInfo",
                 string.Format("The argument must be of type '{0}'.", "IDictionary<string, object>"));
+        }
+
+        [Fact]
+        public void AddDynamicPropertyDictionary_ThrowsIfTwoDifferentPropertiesAreAdded()
+        {
+            // Arrange
+            MockPropertyInfo propertyA = new MockPropertyInfo(typeof(IDictionary<string, object>), "TestA");
+            MockPropertyInfo propertyB = new MockPropertyInfo(typeof(IDictionary<string, object>), "TestB");
+            Mock<StructuralTypeConfiguration> mock = new Mock<StructuralTypeConfiguration> { CallBase = true };
+            mock.Setup(m => m.Name).Returns("TestEntity");
+            mock.Setup(m => m.ClrType).Returns(propertyA.Object.DeclaringType);
+            StructuralTypeConfiguration configuration = mock.Object;
+
+            // Act & Assert
+            ExceptionAssert.DoesNotThrow(() => configuration.AddDynamicPropertyDictionary(propertyA));
+            ExceptionAssert.ThrowsArgument(() => configuration.AddDynamicPropertyDictionary(propertyB),
+                "propertyInfo",
+                string.Format("Found more than one dynamic property container in type '{0}'. Each open type must have at most one dynamic property container.", "Object"));
+        }
+
+        [Fact]
+        public void AddDynamicPropertyDictionary_DoesNotThrowIfSamePropertyIsAdded()
+        {
+            // Arrange
+            MockPropertyInfo property = new MockPropertyInfo(typeof(IDictionary<string, object>), "Test");
+            Mock<StructuralTypeConfiguration> mock = new Mock<StructuralTypeConfiguration> { CallBase = true };
+            mock.Setup(m => m.Name).Returns("TestEntity");
+            mock.Setup(m => m.ClrType).Returns(property.Object.DeclaringType);
+            StructuralTypeConfiguration configuration = mock.Object;
+
+            // Act & Assert
+            ExceptionAssert.DoesNotThrow(() => configuration.AddDynamicPropertyDictionary(property));
+            ExceptionAssert.DoesNotThrow(() => configuration.AddDynamicPropertyDictionary(property));
         }
 
         /// <summary>


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes issue AspNetCoreOData/[#1480](https://github.com/OData/AspNetCoreOData/issues/1480).

### Description

This adds a no-op when calling "AddDynamicPropertyDictionary" with the currently-configured dynamic dictionary property. Previously, an exception would be thrown, indicating that a dynamic property had already been configured. Now, that exception will only be thrown if the method is called with any property other than the currently-configured dynamic dictionary property.

### Checklist (Uncheck if it is not completed)

- [X] *Test cases added*
- [ ] *Build and test with one-click build and test script passed* - (sorry, not sure what this is)

### Additional work necessary

Documentation should not be needed.
