### PR TITLE
Push nightly packages always and release packages only when needed

### DIFF
--- a/build/azure-pipelines-nightly.yml
+++ b/build/azure-pipelines-nightly.yml
@@ -14,6 +14,15 @@ schedules:
     include:
     - main
 
+parameters:
+  - name: PublishMode
+    displayName: Package publishing mode ('NightlyOnly' for nightly packages; 'ReleaseAndNightly' for both release and nightly packages)
+    type: string
+    default: NightlyOnly
+    values:
+    - NightlyOnly
+    - ReleaseAndNightly
+
 resources:
   repositories:
   - repository: self
@@ -40,6 +49,13 @@ variables:
 - group: OData-Shared
 - name: AZURE_ARTIFACTS_FEED
   value: $(ODataFeed)
+- ${{ if eq(parameters.PublishMode, 'NightlyOnly') }}:
+  - name: PackagesToPush
+    value: $(Build.ArtifactStagingDirectory)\Nuget\*Nightly*nupkg
+
+- ${{ if eq(parameters.PublishMode, 'ReleaseAndNightly') }}: 
+  - name: PackagesToPush
+    value: '$(Build.ArtifactStagingDirectory)\Nuget\*.nupkg;$(Build.ArtifactStagingDirectory)\Nuget\*.snupkg'
 
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
@@ -69,7 +85,7 @@ extends:
           - output: nuget
             displayName: 'NuGet push - Packages to Internal Feed'
             packageParentPath: '$(Build.ArtifactStagingDirectory)\Nuget'
-            packagesToPush: '$(Build.ArtifactStagingDirectory)\Nuget\*.nupkg;$(Build.ArtifactStagingDirectory)\Nuget\*.snupkg'
+            packagesToPush: '$(PackagesToPush)'
             nuGetFeedType: internal
             publishVstsFeed: $(ODataPublishFeed)
             allowPackageConflicts: true


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #xxx.*

### Description

### Summary
Adds a `PublishMode` parameter to the nightly pipeline so scheduled runs publish
**only nightly** packages to the internal Azure Artifacts feed by default, while
release packages can still be published on demand.

Mirrors OData/AspNetCoreOData PR #1588 (`fix/push-nightly-always`).

### Changes
- New pipeline parameter `PublishMode`: `NightlyOnly` (default) | `ReleaseAndNightly`.
- New `PackagesToPush` variable selected from `PublishMode`:
  - `NightlyOnly` → `$(Build.ArtifactStagingDirectory)\Nuget\*Nightly*nupkg` (nightly `.nupkg` + `.snupkg`)
  - `ReleaseAndNightly` → `$(Build.ArtifactStagingDirectory)\Nuget\*.nupkg;$(Build.ArtifactStagingDirectory)\Nuget\*.snupkg`
- Internal-feed **NuGet push** step now uses `packagesToPush: '$(PackagesToPush)'`.
- External MyGet nightly push unchanged.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
